### PR TITLE
[fix]: validation 예외 처리

### DIFF
--- a/src/main/java/com/example/bookshop/BookshopApplication.java
+++ b/src/main/java/com/example/bookshop/BookshopApplication.java
@@ -2,8 +2,10 @@ package com.example.bookshop;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class BookshopApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/example/bookshop/global/config/AppConfig.java
+++ b/src/main/java/com/example/bookshop/global/config/AppConfig.java
@@ -1,0 +1,17 @@
+package com.example.bookshop.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class AppConfig {
+
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+}

--- a/src/main/java/com/example/bookshop/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/bookshop/global/config/SecurityConfig.java
@@ -1,0 +1,36 @@
+package com.example.bookshop.global.config;
+
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.CsrfConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer.FrameOptionsConfig;
+import org.springframework.security.config.annotation.web.configurers.HttpBasicConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+
+    @Bean
+    protected SecurityFilterChain configure(HttpSecurity httpSecurity) throws Exception {
+
+        httpSecurity
+                .formLogin(AbstractHttpConfigurer::disable)
+                .csrf(CsrfConfigurer::disable) // 전체적으로 CSRF 비활성화
+                .authorizeHttpRequests(request -> request
+                        .requestMatchers("/api/user/**").permitAll()  // 정확히 이렇게 되어 있어야 함
+                        .anyRequest().authenticated()
+                );
+        return httpSecurity.build();
+    }
+
+
+}

--- a/src/main/java/com/example/bookshop/global/dto/ResultDto.java
+++ b/src/main/java/com/example/bookshop/global/dto/ResultDto.java
@@ -1,0 +1,18 @@
+package com.example.bookshop.global.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@RequiredArgsConstructor(staticName = "of")
+public class ResultDto<T> {
+
+    private final String message;
+
+    private final T data;
+
+
+
+}

--- a/src/main/java/com/example/bookshop/global/entity/BaseEntity.java
+++ b/src/main/java/com/example/bookshop/global/entity/BaseEntity.java
@@ -1,0 +1,31 @@
+package com.example.bookshop.global.entity;
+
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+public abstract class BaseEntity {
+
+
+    @CreatedDate
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+
+
+
+}

--- a/src/main/java/com/example/bookshop/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/bookshop/global/exception/ErrorCode.java
@@ -9,6 +9,9 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum ErrorCode {
 
+    INVALID_INPUT(HttpStatus.BAD_REQUEST, "잘못된 입력입니다."),
+    INVALID_PATTERN(HttpStatus.BAD_REQUEST, "잘못된 패턴입니다."),
+    PAST_BIRTHDAY(HttpStatus.BAD_REQUEST, "과거 날짜를 입력해주세요."),
     USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "사용자를 찾을 수 없습니다."),
     EXISTS_BY_EMAIL(HttpStatus.BAD_REQUEST, "이미 사용중인 이메일입니다."),
     EXISTS_BY_LOGIN_ID(HttpStatus.BAD_REQUEST, "이미 사용중인 아이디입니다."),

--- a/src/main/java/com/example/bookshop/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/bookshop/global/exception/GlobalExceptionHandler.java
@@ -1,28 +1,69 @@
 package com.example.bookshop.global.exception;
 
+import com.example.bookshop.global.exception.dto.ErrorResponse;
+import com.example.bookshop.global.exception.dto.FieldErrorDetail;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+    private static final Map<String, ErrorCode> CODE_MAP = Map.of(
+            "NotBlank", ErrorCode.INVALID_INPUT,
+            "NotNull", ErrorCode.INVALID_INPUT,
+            "Pattern", ErrorCode.INVALID_PATTERN,
+            "Positive", ErrorCode.INVALID_PATTERN,
+            "Email", ErrorCode.INVALID_PATTERN,
+            "Past", ErrorCode.PAST_BIRTHDAY
+    );
 
     @ExceptionHandler(CustomException.class)
     protected ResponseEntity<ErrorResponse> handleCustomException(CustomException e) {
 
         log.error("CustomException 발생 : {} " , e.getErrorMessage());
 
-        ErrorResponse errorResponse = ErrorResponse.builder()
-                .statusCode(e.getErrorCode().statusCode())
-                .errorCode(e.getErrorCode())
-                .errorMessage(e.getErrorMessage())
-                .build();
 
 
-        return new ResponseEntity<>(errorResponse, e.getErrorCode().getStatus());
+
+        return new ResponseEntity<>(ErrorResponse.of(e.getErrorCode()),
+                e.getErrorCode().getStatus());
 
     }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    protected ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+
+        log.error("MethodArgumentNotValidException 발생 : {}", e.getMessage());
+
+        List<FieldErrorDetail> details = e.getBindingResult()
+                .getFieldErrors()
+                .stream()
+                .map(error -> FieldErrorDetail.of(
+                        error.getField(),
+                        error.getCode(),
+                        error.getDefaultMessage()
+                ))
+                .collect(Collectors.toList());
+
+        String firstCode = Optional.ofNullable(e.getBindingResult().getFieldErrors().get(0).getCode())
+                .orElse("NotBlank");
+        ErrorCode errorCode = map(firstCode);
+
+        return new ResponseEntity<>(ErrorResponse.of(errorCode, details),errorCode.getStatus());
+    }
+
+
+    private static ErrorCode map(String validationCode) {
+        return CODE_MAP.getOrDefault(validationCode, ErrorCode.INVALID_INPUT);
+    }
+
 }

--- a/src/main/java/com/example/bookshop/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/bookshop/global/exception/GlobalExceptionHandler.java
@@ -13,7 +13,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(CustomException.class)
     protected ResponseEntity<ErrorResponse> handleCustomException(CustomException e) {
 
-        log.error("CustomException 발생 : {} " , e.getErrorMessage(), e);
+        log.error("CustomException 발생 : {} " , e.getErrorMessage());
 
         ErrorResponse errorResponse = ErrorResponse.builder()
                 .statusCode(e.getErrorCode().statusCode())

--- a/src/main/java/com/example/bookshop/global/exception/dto/ErrorResponse.java
+++ b/src/main/java/com/example/bookshop/global/exception/dto/ErrorResponse.java
@@ -1,0 +1,39 @@
+package com.example.bookshop.global.exception.dto;
+
+import com.example.bookshop.global.exception.ErrorCode;
+import lombok.*;
+
+import java.util.List;
+import java.util.Map;
+
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ErrorResponse {
+
+    private int statusCode;
+    private ErrorCode errorCode;
+    private String errorMessage;
+    private List<FieldErrorDetail> details;
+
+
+
+    public static ErrorResponse of(ErrorCode errorCode, List<FieldErrorDetail> details) {
+
+
+        return ErrorResponse.builder()
+                .statusCode(errorCode.statusCode())
+                .errorCode(errorCode)
+                .errorMessage(errorCode.getMessage())
+                .details(details)
+                .build();
+
+    }
+
+    public static ErrorResponse of(ErrorCode errorCode) {
+        return ErrorResponse.of(errorCode, List.of());
+    }
+
+}

--- a/src/main/java/com/example/bookshop/global/exception/dto/FieldErrorDetail.java
+++ b/src/main/java/com/example/bookshop/global/exception/dto/FieldErrorDetail.java
@@ -1,0 +1,15 @@
+package com.example.bookshop.global.exception.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(staticName = "of")
+public class FieldErrorDetail {
+
+    private final String field;
+    private final String code;
+    private final String Message;
+
+
+}

--- a/src/main/java/com/example/bookshop/user/controller/UserController.java
+++ b/src/main/java/com/example/bookshop/user/controller/UserController.java
@@ -1,0 +1,33 @@
+package com.example.bookshop.user.controller;
+
+
+import com.example.bookshop.global.dto.ResultDto;
+import com.example.bookshop.user.dto.SignUpUserDto;
+import com.example.bookshop.user.service.UserService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/user")
+public class UserController {
+
+
+    private final UserService userService;
+
+    @PostMapping("/signup")
+    public ResponseEntity<ResultDto<SignUpUserDto.Response>> signUpUser(@RequestBody @Valid SignUpUserDto.Request request) {
+
+        ResultDto<SignUpUserDto.Response> responseResultDto = userService.signUpUser(request);
+
+        return ResponseEntity.ok(responseResultDto);
+
+    }
+
+}

--- a/src/main/java/com/example/bookshop/user/dto/SignUpUserDto.java
+++ b/src/main/java/com/example/bookshop/user/dto/SignUpUserDto.java
@@ -1,0 +1,108 @@
+package com.example.bookshop.user.dto;
+
+import com.example.bookshop.user.entity.UserEntity;
+import com.example.bookshop.user.type.UserType;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.*;
+
+import java.time.LocalDate;
+
+
+public class SignUpUserDto {
+
+    @Getter
+    @AllArgsConstructor
+    @Setter
+    public static class Request {
+
+        @NotBlank(message = "아이디를 입력해주세요.")
+        private String loginId;
+
+        @NotBlank(message = "비밀번호를 입력해주세요.")
+        @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*\\d)(?=.*[~!@#$%^&*()])[a-zA-Z\\d~!@#$%^&*()]{8,13}$",
+        message = "비밀번호는 영어 대소문자, 숫자, 특수문자를 포함한 8자 이상이어야 합니다.")
+        private String password;
+
+        @NotBlank(message = "비밀번호 확인을 입력해주세요.")
+        @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*\\d)(?=.*[~!@#$%^&*()])[a-zA-Z\\d~!@#$%^&*()]{8,13}$",
+                message = "비밀번호는 영어 대소문자, 숫자, 특수문자를 포함한 8자 이상이어야 합니다.")
+        private String checkPassword;
+
+        @NotBlank(message = "이메일을 입력해주세요.")
+        @Email(message = "이메일 형식으로 입력해주세요.")
+        private String email;
+
+        @NotBlank(message = "닉네임을 입력해주세요.")
+        private String nickname;
+
+        @JsonFormat(shape = JsonFormat.Shape.STRING
+                , pattern = "yyyyMMdd"
+                , timezone = "Asia/Seoul")
+        private LocalDate birth;
+
+        @NotBlank(message = "휴대폰 번호를 입력해주세요.")
+        @Pattern(regexp = "^01[016789]-\\d{3,4}-\\d{4}$", message = "휴대폰 번호 형식이 올바르지 않습니다.")
+        private String phone;
+
+        @NotBlank(message = "주소를 입력해주세요.")
+        private String address;
+
+        private String userType;
+
+        public static UserEntity toEntity(Request request) {
+
+            return UserEntity.builder()
+                    .loginId(request.loginId)
+                    .password(request.password)
+                    .nickname(request.nickname)
+                    .email(request.email)
+                    .birth(request.birth)
+                    .phone(request.phone)
+                    .address(request.address)
+                    .userType(UserType.USER)
+                    .build();
+
+        }
+
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    public static class Response {
+
+        private String loginId;
+
+        private String email;
+
+        private LocalDate birth;
+
+        private String phone;
+
+        private String address;
+
+        private String nickname;
+
+        private String userType;
+
+        public static Response fromDto(UserDto userDto) {
+
+            return Response.builder()
+                    .loginId(userDto.getLoginId())
+                    .email(userDto.getEmail())
+                    .birth(userDto.getBirth())
+                    .phone(userDto.getPhone())
+                    .address(userDto.getAddress())
+                    .nickname(userDto.getNickname())
+                    .userType(String.valueOf(userDto.getUserType()))
+                    .build();
+        }
+
+
+    }
+
+}

--- a/src/main/java/com/example/bookshop/user/dto/SignUpUserDto.java
+++ b/src/main/java/com/example/bookshop/user/dto/SignUpUserDto.java
@@ -39,7 +39,7 @@ public class SignUpUserDto {
         private String nickname;
 
         @JsonFormat(shape = JsonFormat.Shape.STRING
-                , pattern = "yyyyMMdd"
+                , pattern = "yyyy-MM-dd"
                 , timezone = "Asia/Seoul")
         private LocalDate birth;
 
@@ -50,7 +50,6 @@ public class SignUpUserDto {
         @NotBlank(message = "주소를 입력해주세요.")
         private String address;
 
-        private String userType;
 
         public static UserEntity toEntity(Request request) {
 

--- a/src/main/java/com/example/bookshop/user/dto/UserDto.java
+++ b/src/main/java/com/example/bookshop/user/dto/UserDto.java
@@ -1,0 +1,50 @@
+package com.example.bookshop.user.dto;
+
+import com.example.bookshop.user.entity.UserEntity;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class UserDto {
+
+    private Long userId;
+
+    private String loginId;
+
+    private String password;
+
+    private String email;
+
+    private LocalDate birth;
+
+    private String phone;
+
+    private String address;
+
+    private String nickname;
+
+    private String userType;
+
+    public static UserDto fromEntity(UserEntity userEntity) {
+
+        return UserDto.builder()
+                .userId(userEntity.getUserId())
+                .loginId(userEntity.getLoginId())
+                .password(userEntity.getPassword())
+                .email(userEntity.getEmail())
+                .birth(userEntity.getBirth())
+                .phone(userEntity.getPhone())
+                .address(userEntity.getAddress())
+                .nickname(userEntity.getNickname())
+                .userType(String.valueOf(userEntity.getUserType()))
+                .build();
+    }
+
+}

--- a/src/main/java/com/example/bookshop/user/entity/UserEntity.java
+++ b/src/main/java/com/example/bookshop/user/entity/UserEntity.java
@@ -1,0 +1,57 @@
+package com.example.bookshop.user.entity;
+
+
+import com.example.bookshop.global.entity.BaseEntity;
+import com.example.bookshop.user.type.UserType;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Getter
+@Setter
+@Entity
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class UserEntity extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long userId;
+
+    @Column(nullable = false)
+    private String loginId;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Column(nullable = false)
+    private String email;
+
+    @Column(nullable = false)
+    private LocalDate birth;
+
+    @Column(nullable = false)
+    private String phone;
+
+    @Column(nullable = false)
+    private String address;
+
+    @Column(nullable = false)
+    private String nickname;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private UserType userType;
+
+    @Builder.Default
+    private boolean emailAuth = false;
+
+
+    public void setEmailAuth() {
+        this.emailAuth = true;
+    }
+
+
+}

--- a/src/main/java/com/example/bookshop/user/repository/UserRepository.java
+++ b/src/main/java/com/example/bookshop/user/repository/UserRepository.java
@@ -1,0 +1,18 @@
+package com.example.bookshop.user.repository;
+
+
+import com.example.bookshop.user.entity.UserEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserRepository extends JpaRepository<UserEntity, Long> {
+
+
+    boolean existsByLoginId(String loginId);
+
+    boolean existsByEmail(String email);
+
+    boolean existsByNickname(String nickname);
+
+}

--- a/src/main/java/com/example/bookshop/user/service/UserService.java
+++ b/src/main/java/com/example/bookshop/user/service/UserService.java
@@ -1,0 +1,11 @@
+package com.example.bookshop.user.service;
+
+import com.example.bookshop.global.dto.ResultDto;
+import com.example.bookshop.user.dto.SignUpUserDto;
+import org.springframework.stereotype.Service;
+
+@Service
+public interface UserService {
+
+    ResultDto<SignUpUserDto.Response> signUpUser(SignUpUserDto.Request signUpUserDto);
+}

--- a/src/main/java/com/example/bookshop/user/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/example/bookshop/user/service/impl/UserServiceImpl.java
@@ -1,0 +1,59 @@
+package com.example.bookshop.user.service.impl;
+
+import com.example.bookshop.global.dto.ResultDto;
+import com.example.bookshop.global.exception.CustomException;
+import com.example.bookshop.user.dto.SignUpUserDto;
+import com.example.bookshop.user.dto.UserDto;
+import com.example.bookshop.user.entity.UserEntity;
+import com.example.bookshop.user.repository.UserRepository;
+import com.example.bookshop.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.example.bookshop.global.exception.ErrorCode.*;
+
+
+@Service
+@RequiredArgsConstructor
+public class UserServiceImpl implements UserService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Override
+    @Transactional
+    public ResultDto<SignUpUserDto.Response> signUpUser(SignUpUserDto.Request request) {
+
+        if (!request.getPassword().equals(request.getCheckPassword())) {
+            throw new CustomException(PASSWORD_MISMATCH);
+        }
+
+        request.setPassword(passwordEncoder.encode(request.getPassword()));
+
+        boolean byEmail = userRepository.existsByEmail(request.getEmail());
+
+        boolean byLoginId = userRepository.existsByLoginId(request.getLoginId());
+
+        boolean byNickname = userRepository.existsByNickname(request.getNickname());
+
+        if (byEmail) {
+            throw new CustomException(EXISTS_BY_EMAIL);
+        }
+
+        if (byLoginId) {
+            throw new CustomException(EXISTS_BY_LOGIN_ID);
+        }
+        if (byNickname) {
+            throw new CustomException(EXISTS_BY_NICKNAME);
+        }
+
+        UserEntity user = userRepository.save(SignUpUserDto.Request.toEntity(request));
+
+
+
+
+        return ResultDto.of("회원가입에 성공하였습니다.", SignUpUserDto.Response.fromDto(UserDto.fromEntity(user)));
+    }
+}

--- a/src/main/java/com/example/bookshop/user/type/UserType.java
+++ b/src/main/java/com/example/bookshop/user/type/UserType.java
@@ -1,0 +1,16 @@
+package com.example.bookshop.user.type;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum UserType {
+
+
+    USER("ROLE_USER"),
+    SELLER("ROLE_SELLER"),;
+
+
+    private final String description;
+}


### PR DESCRIPTION
## ✨ 변경 사항

### 📌 AS-IS
- 회원가입 API는 구현 완료 상태였으나, Validation 실패 시 응답 바디 없이 403 Forbidden 에러가 발생
- 전역 예외 처리 구조가 없어, 유효성 검증 실패

---

### 🚀 TO-BE
- 회원가입 요청 시 `@Valid` 유효성 실패에 대해 전역 예외 처리 추가
  - `GlobalExceptionHandler`에 `MethodArgumentNotValidException` 핸들러 구현
  - 잘못된 필드명, 제약 조건 코드, 메시지를 포함한 상세 에러 응답 구조(`FieldErrorDetail`, `ErrorResponse`) 설계

---

## ✅ 체크리스트

- [x] `MethodArgumentNotValidException` 전역 예외 처리 구현
- [x] 기존 `CustomException` 기반 예외 구조와 통합
- [x] Postman 테스트 완료 → Validation 실패 시 403 → 400 + 상세 메시지로 변경 확인

---
