### PR TITLE
[feat] : 이메일 인증 구현

### DIFF
--- a/src/main/java/com/example/bookshop/global/config/RedisConfig.java
+++ b/src/main/java/com/example/bookshop/global/config/RedisConfig.java
@@ -1,0 +1,45 @@
+package com.example.bookshop.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory);
+
+        StringRedisSerializer stringSerializer = new StringRedisSerializer();
+
+        // key, value 직렬화
+        redisTemplate.setKeySerializer(stringSerializer);
+        redisTemplate.setValueSerializer(stringSerializer);
+
+        // hash key, value 직렬화
+        redisTemplate.setHashKeySerializer(stringSerializer);
+        redisTemplate.setHashValueSerializer(stringSerializer);
+
+        return redisTemplate;
+    }
+
+
+
+}

--- a/src/main/java/com/example/bookshop/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/bookshop/global/config/SecurityConfig.java
@@ -2,8 +2,11 @@ package com.example.bookshop.global.config;
 
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -17,6 +20,7 @@ import org.springframework.security.web.SecurityFilterChain;
 @EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
+
 
 
     @Bean

--- a/src/main/java/com/example/bookshop/global/dto/CheckDto.java
+++ b/src/main/java/com/example/bookshop/global/dto/CheckDto.java
@@ -1,0 +1,15 @@
+package com.example.bookshop.global.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+@Builder
+public class CheckDto {
+
+    private boolean success;
+    private String message;
+
+}

--- a/src/main/java/com/example/bookshop/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/bookshop/global/exception/ErrorCode.java
@@ -9,6 +9,9 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum ErrorCode {
 
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "내부 서버 오류입니다."),
+
+
     INVALID_INPUT(HttpStatus.BAD_REQUEST, "잘못된 입력입니다."),
     INVALID_PATTERN(HttpStatus.BAD_REQUEST, "잘못된 패턴입니다."),
     PAST_BIRTHDAY(HttpStatus.BAD_REQUEST, "과거 날짜를 입력해주세요."),
@@ -16,6 +19,8 @@ public enum ErrorCode {
     EXISTS_BY_EMAIL(HttpStatus.BAD_REQUEST, "이미 사용중인 이메일입니다."),
     EXISTS_BY_LOGIN_ID(HttpStatus.BAD_REQUEST, "이미 사용중인 아이디입니다."),
     EXISTS_BY_NICKNAME(HttpStatus.BAD_REQUEST, "이미 사용중인 닉네임입니다."),
+    EMAIL_NOT_FOUND(HttpStatus.BAD_REQUEST, "이메일을 찾을 수 없습니다."),
+    INVALID_AUTH_CODE(HttpStatus.BAD_REQUEST, "유효하지 않은 인증번호입니다."),
     PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST, "비밀번호와 비밀번호 확인이 일치하지 않습니다.");
 
 

--- a/src/main/java/com/example/bookshop/global/service/MailService.java
+++ b/src/main/java/com/example/bookshop/global/service/MailService.java
@@ -1,0 +1,124 @@
+package com.example.bookshop.global.service;
+
+import com.example.bookshop.global.dto.CheckDto;
+import com.example.bookshop.global.exception.CustomException;
+import com.example.bookshop.global.exception.ErrorCode;
+import com.example.bookshop.user.entity.UserEntity;
+import com.example.bookshop.user.repository.UserRepository;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+
+import java.util.Random;
+
+import static com.example.bookshop.global.exception.ErrorCode.*;
+
+@Service
+@RequiredArgsConstructor
+public class MailService {
+
+    private final JavaMailSender javaMailSender;
+
+    private final RedisService redisService;
+
+    private final UserRepository userRepository;
+
+    private static final Long EMAIL_TOKEN_EXPIRE = 3L;
+
+    private static final int CODE_LENGTH = 6;
+
+    private static final String EMAIL_PREFIX = "Email-Auth: ";
+
+
+    public CheckDto sendAuthMail(String email) {
+
+        String code = createRandomMail();
+
+
+        MimeMessage mimeMessage = javaMailSender.createMimeMessage();
+
+        MimeMessageHelper mimeMessageHelper = new MimeMessageHelper(mimeMessage, "UTF-8");
+
+        if (!userRepository.existsByEmail(email)) {
+            throw new CustomException(EMAIL_NOT_FOUND);
+        }
+
+        try {
+
+            mimeMessageHelper.setTo(email);
+
+            mimeMessageHelper.setSubject("회원가입 이메일 인증번호입니다.");
+
+            String msg = "<div style='margin:20px;'>"
+                    + "<h1> 안녕하세요 도서 쇼핑몰 입니다. </h1>"
+                    + "<br>"
+                    + "<p>아래 코드를 입력해주세요<p>"
+                    + "<br>"
+                    + "<p>감사합니다.<p>"
+                    + "<br>"
+                    + "<div align='center' style='border:1px solid black; font-family:verdana';>"
+                    + "<h3 style='color:blue;'>회원가입 인증 코드입니다.</h3>"
+                    + "<div style='font-size:130%'>"
+                    + "CODE : <strong>" + code + "</strong><div><br/> "
+                    + "</div>";
+
+            mimeMessageHelper.setText(msg, true);
+
+            javaMailSender.send(mimeMessage);
+            redisService.setDataExpire(EMAIL_PREFIX + email, code, EMAIL_TOKEN_EXPIRE);
+
+        } catch (MessagingException e) {
+
+            throw new CustomException(INTERNAL_SERVER_ERROR);
+        }
+
+
+
+        return CheckDto.builder()
+                .success(true)
+                .message("인증번호를 전송하였습니다.")
+                .build();
+    }
+
+    public CheckDto checkAuthCode(String email, String code) {
+
+        String data = redisService.getData(EMAIL_PREFIX + email);
+
+        if (data == null || !data.equals(code)) {
+            throw new CustomException(INVALID_AUTH_CODE);
+        }
+
+        UserEntity userEntity = userRepository.findByEmail(email)
+                .orElseThrow(() -> new CustomException(EMAIL_NOT_FOUND));
+
+        userEntity.setEmailAuth();
+
+        userRepository.save(userEntity);
+
+        redisService.deleteData(EMAIL_PREFIX + email);
+
+        return CheckDto.builder()
+                .success(true)
+                .message("이메일 인증에 성공하였습니다.")
+                .build();
+    }
+
+    private String createRandomMail() {
+
+        Random random = new Random();
+
+        StringBuilder sb = new StringBuilder();
+
+        for (int i = 0; i < CODE_LENGTH; i++) {
+            sb.append(random.nextInt(10));
+        }
+
+        return sb.toString();
+
+    }
+
+
+}

--- a/src/main/java/com/example/bookshop/global/service/RedisService.java
+++ b/src/main/java/com/example/bookshop/global/service/RedisService.java
@@ -1,0 +1,41 @@
+package com.example.bookshop.global.service;
+
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+
+@Service
+@RequiredArgsConstructor
+public class RedisService {
+
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+
+    public void setDataExpire(String key, String value, Long expiredTime) {
+
+        ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
+
+        valueOperations.set(key, value, Duration.ofMinutes(expiredTime));
+
+    }
+
+    public String getData(String key) {
+
+        ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
+
+        return valueOperations.get(key);
+
+    }
+
+    public void deleteData(String key) {
+
+        redisTemplate.delete(key);
+
+    }
+
+}

--- a/src/main/java/com/example/bookshop/user/controller/UserController.java
+++ b/src/main/java/com/example/bookshop/user/controller/UserController.java
@@ -1,7 +1,11 @@
 package com.example.bookshop.user.controller;
 
 
+import com.example.bookshop.global.dto.CheckDto;
 import com.example.bookshop.global.dto.ResultDto;
+import com.example.bookshop.global.service.MailService;
+import com.example.bookshop.user.dto.CheckEmailDto;
+import com.example.bookshop.user.dto.SendMailDto;
 import com.example.bookshop.user.dto.SignUpUserDto;
 import com.example.bookshop.user.service.UserService;
 import jakarta.validation.Valid;
@@ -21,12 +25,44 @@ public class UserController {
 
     private final UserService userService;
 
+    private final MailService mailService;
+
     @PostMapping("/signup")
     public ResponseEntity<ResultDto<SignUpUserDto.Response>> signUpUser(@RequestBody @Valid SignUpUserDto.Request request) {
 
         ResultDto<SignUpUserDto.Response> responseResultDto = userService.signUpUser(request);
 
         return ResponseEntity.ok(responseResultDto);
+
+    }
+
+    @PostMapping("/check-email")
+    public ResponseEntity<CheckDto> checkEmail(
+            @RequestBody SendMailDto sendMailDto
+
+    ) {
+
+        CheckDto checkDto = userService.checkEmail(sendMailDto.getEmail());
+
+        return ResponseEntity.ok(checkDto);
+    }
+
+    @PostMapping("/send-mail")
+    public ResponseEntity<CheckDto> sendEmailAuth(
+            @RequestBody SendMailDto sendMailDto
+            ) {
+
+        CheckDto checkDto = mailService.sendAuthMail(sendMailDto.getEmail());
+
+        return ResponseEntity.ok(checkDto);
+    }
+
+    @PostMapping("check-auth-code")
+    public ResponseEntity<CheckDto> checkAuthCode(@RequestBody CheckEmailDto checkEmailDto) {
+
+        CheckDto checkDto = mailService.checkAuthCode(checkEmailDto.getEmail(), checkEmailDto.getCode());
+
+        return ResponseEntity.ok(checkDto);
 
     }
 

--- a/src/main/java/com/example/bookshop/user/dto/CheckEmailDto.java
+++ b/src/main/java/com/example/bookshop/user/dto/CheckEmailDto.java
@@ -1,0 +1,12 @@
+package com.example.bookshop.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CheckEmailDto {
+
+    private String email;
+    private String code;
+}

--- a/src/main/java/com/example/bookshop/user/dto/SendMailDto.java
+++ b/src/main/java/com/example/bookshop/user/dto/SendMailDto.java
@@ -1,0 +1,15 @@
+package com.example.bookshop.user.dto;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class SendMailDto {
+
+    private String email;
+
+}

--- a/src/main/java/com/example/bookshop/user/dto/SignUpUserDto.java
+++ b/src/main/java/com/example/bookshop/user/dto/SignUpUserDto.java
@@ -16,6 +16,7 @@ public class SignUpUserDto {
     @Getter
     @AllArgsConstructor
     @Setter
+    @Builder
     public static class Request {
 
         @NotBlank(message = "아이디를 입력해주세요.")

--- a/src/main/java/com/example/bookshop/user/repository/UserRepository.java
+++ b/src/main/java/com/example/bookshop/user/repository/UserRepository.java
@@ -5,9 +5,12 @@ import com.example.bookshop.user.entity.UserEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface UserRepository extends JpaRepository<UserEntity, Long> {
 
+    Optional<UserEntity> findByEmail(String email);
 
     boolean existsByLoginId(String loginId);
 

--- a/src/main/java/com/example/bookshop/user/service/UserService.java
+++ b/src/main/java/com/example/bookshop/user/service/UserService.java
@@ -1,5 +1,6 @@
 package com.example.bookshop.user.service;
 
+import com.example.bookshop.global.dto.CheckDto;
 import com.example.bookshop.global.dto.ResultDto;
 import com.example.bookshop.user.dto.SignUpUserDto;
 import org.springframework.stereotype.Service;
@@ -8,4 +9,6 @@ import org.springframework.stereotype.Service;
 public interface UserService {
 
     ResultDto<SignUpUserDto.Response> signUpUser(SignUpUserDto.Request signUpUserDto);
+
+    CheckDto checkEmail(String email);
 }

--- a/src/main/java/com/example/bookshop/user/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/example/bookshop/user/service/impl/UserServiceImpl.java
@@ -26,28 +26,14 @@ public class UserServiceImpl implements UserService {
     @Transactional
     public ResultDto<SignUpUserDto.Response> signUpUser(SignUpUserDto.Request request) {
 
+
+        validationUserInfo(request);
+
         if (!request.getPassword().equals(request.getCheckPassword())) {
             throw new CustomException(PASSWORD_MISMATCH);
         }
 
         request.setPassword(passwordEncoder.encode(request.getPassword()));
-
-        boolean byEmail = userRepository.existsByEmail(request.getEmail());
-
-        boolean byLoginId = userRepository.existsByLoginId(request.getLoginId());
-
-        boolean byNickname = userRepository.existsByNickname(request.getNickname());
-
-        if (byEmail) {
-            throw new CustomException(EXISTS_BY_EMAIL);
-        }
-
-        if (byLoginId) {
-            throw new CustomException(EXISTS_BY_LOGIN_ID);
-        }
-        if (byNickname) {
-            throw new CustomException(EXISTS_BY_NICKNAME);
-        }
 
         UserEntity user = userRepository.save(SignUpUserDto.Request.toEntity(request));
 
@@ -56,4 +42,20 @@ public class UserServiceImpl implements UserService {
 
         return ResultDto.of("회원가입에 성공하였습니다.", SignUpUserDto.Response.fromDto(UserDto.fromEntity(user)));
     }
+
+    private void validationUserInfo(SignUpUserDto.Request request) {
+
+        if (userRepository.existsByEmail(request.getEmail())) {
+            throw new CustomException(EXISTS_BY_EMAIL);
+        }
+
+        if (userRepository.existsByLoginId(request.getLoginId())) {
+            throw new CustomException(EXISTS_BY_LOGIN_ID);
+        }
+        if (userRepository.existsByNickname(request.getNickname())) {
+            throw new CustomException(EXISTS_BY_NICKNAME);
+        }
+    }
+
+
 }

--- a/src/main/java/com/example/bookshop/user/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/example/bookshop/user/service/impl/UserServiceImpl.java
@@ -1,5 +1,6 @@
 package com.example.bookshop.user.service.impl;
 
+import com.example.bookshop.global.dto.CheckDto;
 import com.example.bookshop.global.dto.ResultDto;
 import com.example.bookshop.global.exception.CustomException;
 import com.example.bookshop.user.dto.SignUpUserDto;
@@ -41,6 +42,22 @@ public class UserServiceImpl implements UserService {
 
 
         return ResultDto.of("회원가입에 성공하였습니다.", SignUpUserDto.Response.fromDto(UserDto.fromEntity(user)));
+    }
+
+    @Override
+    @Transactional
+    public CheckDto checkEmail(String email) {
+
+        boolean exists = userRepository.existsByEmail(email);
+
+        if (exists) {
+            throw new CustomException(EXISTS_BY_EMAIL);
+        }
+
+        return CheckDto.builder()
+                .success(true)
+                .message("사용가능한 이메일 입니다.").build();
+
     }
 
     private void validationUserInfo(SignUpUserDto.Request request) {

--- a/src/test/java/com/example/bookshop/user/service/impl/UserServiceImplTest.java
+++ b/src/test/java/com/example/bookshop/user/service/impl/UserServiceImplTest.java
@@ -1,0 +1,86 @@
+package com.example.bookshop.user.service.impl;
+
+import com.example.bookshop.global.dto.ResultDto;
+import com.example.bookshop.global.exception.CustomException;
+import com.example.bookshop.user.dto.SignUpUserDto;
+import com.example.bookshop.user.repository.UserRepository;
+import com.example.bookshop.user.service.UserService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+
+import static com.example.bookshop.global.exception.ErrorCode.EXISTS_BY_EMAIL;
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+@ActiveProfiles("test")
+class UserServiceImplTest {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private UserService userService;
+
+
+    @Test
+    @DisplayName("User_SignUp_Success")
+    void signUpUser() {
+        // given
+        SignUpUserDto.Request request = SignUpUserDto.Request.builder()
+                .loginId("rwg1279")
+                .password("rhdwlgns@12")
+                .checkPassword("rhdwlgns@12")
+                .email("rwg1279@naver.com")
+                .nickname("JI")
+                .birth(LocalDate.parse("1997-07-24"))
+                .phone("010-4599-1719")
+                .address("인천")
+                .build();
+
+
+        // when
+        ResultDto<SignUpUserDto.Response> responseResultDto = userService.signUpUser(request);
+
+        // then
+        assertEquals("회원가입에 성공하였습니다.", responseResultDto.getMessage());
+    }
+
+    @Test
+    @DisplayName("User_SignUp_Fail_중복_이메일")
+    void signUpFail_duplicateEmail() {
+        // given
+        SignUpUserDto.Request request = SignUpUserDto.Request.builder()
+                .loginId("user1")
+                .password("Test1234!@")
+                .checkPassword("Test1234!@")
+                .email("duplicate@naver.com")
+                .nickname("nick1")
+                .birth(LocalDate.parse("1997-07-24"))
+                .phone("010-1234-5678")
+                .address("서울")
+                .build();
+
+        // 1차 회원가입 → 정상 가입
+        userService.signUpUser(request);
+
+        // 2차 회원가입 → 같은 이메일로 재시도
+        CustomException exception = assertThrows(CustomException.class, () -> {
+            userService.signUpUser(request);
+        });
+
+        // then
+        assertEquals(EXISTS_BY_EMAIL.getMessage(), exception.getMessage());
+    }
+
+
+
+
+
+}


### PR DESCRIPTION
## ✨ 변경 사항

### 📌 AS-IS
- 이메일 인증 기능 미구현  
- 이메일 중복 여부는 회원가입 시점에서만 검증

---

### 🚀 TO-BE
- 이메일 인증 기능 구현 완료  
  - 이메일 인증 요청 API 구현: `checkEmail(String email)`
  - 인증 코드 발송 서비스 구현 (`JavaMailSender` 사용)
  - 인증 코드 Redis 저장 및 만료시간 설정
  - 이메일 인증 코드 검증 API 구현

- Redis 연동
  - 인증코드 저장 및 TTL 설정 (`RedisTemplate` 사용)
  - 이메일 인증 만료 시간 설정 (예: 3분)

---

## ✅ 체크리스트

- [x] 이메일 중복 확인 API 구현
- [x] 이메일 인증 요청 API 구현 
- [x] 이메일 인증 코드 검증 API 구현
- [x] `JavaMailSender`를 활용한 메일 발송 기능 구현
- [x] API 테스트 

---
