### PR TITLE
[feat] : JWT 로그인 및 토큰 발급 기능 구현

### DIFF
--- a/src/main/java/com/example/bookshop/auth/controller/AuthController.java
+++ b/src/main/java/com/example/bookshop/auth/controller/AuthController.java
@@ -1,0 +1,45 @@
+package com.example.bookshop.auth.controller;
+
+
+import com.example.bookshop.auth.dto.LoginDto;
+import com.example.bookshop.auth.dto.TokenDto;
+import com.example.bookshop.auth.service.AuthService;
+import com.example.bookshop.global.dto.ResultDto;
+import com.example.bookshop.user.dto.UserDto;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/auth")
+public class AuthController {
+
+    private final AuthService authService;
+
+
+
+    @PostMapping("/login")
+    public ResponseEntity<ResultDto<LoginDto.Response>> loginUser(@RequestBody @Valid LoginDto.Request request) {
+
+        UserDto userDto = authService.LoginUser(request.getLoginId(), request.getPassword());
+
+        TokenDto token = authService.getToken(userDto);
+
+
+        HttpHeaders headers = new HttpHeaders();
+
+        headers.set("Authorization", token.getAccessToken());
+
+        return ResponseEntity.ok()
+                .headers(headers)
+                .body(ResultDto.of("로그인에 성공하였습니다.", LoginDto.Response.fromDto(userDto, token.getRefreshToken())));
+
+    }
+
+}

--- a/src/main/java/com/example/bookshop/auth/dto/LoginDto.java
+++ b/src/main/java/com/example/bookshop/auth/dto/LoginDto.java
@@ -1,0 +1,66 @@
+package com.example.bookshop.auth.dto;
+
+import com.example.bookshop.user.dto.UserDto;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+
+public class LoginDto {
+
+
+    @Getter
+    @AllArgsConstructor
+    public static class Request {
+
+        @NotBlank(message = "아이디를 입력해주세요.")
+        private String loginId;
+
+        @NotBlank(message = "비밀번호를 입력해주세요.")
+        @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*\\d)(?=.*[~!@#$%^&*()])[a-zA-Z\\d~!@#$%^&*()]{8,13}$",
+                message = "비밀번호는 영어 대소문자, 숫자, 특수문자를 포함한 8자 이상이어야 합니다.")
+        private String password;
+
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @Builder
+    public static class Response {
+
+        private String loginId;
+
+        private String email;
+
+        private String birth;
+
+        private String phone;
+
+        private String address;
+
+        private String nickname;
+
+        private String userType;
+
+        private String refreshToken;
+
+        public static Response fromDto(UserDto userDto, String refreshToken) {
+
+            return Response.builder()
+                    .loginId(userDto.getLoginId())
+                    .email(userDto.getEmail())
+                    .birth(userDto.getUserType())
+                    .phone(userDto.getPhone())
+                    .address(userDto.getAddress())
+                    .nickname(userDto.getNickname())
+                    .userType(userDto.getUserType())
+                    .refreshToken(refreshToken)
+                    .build();
+
+        }
+
+    }
+
+}

--- a/src/main/java/com/example/bookshop/auth/dto/TokenDto.java
+++ b/src/main/java/com/example/bookshop/auth/dto/TokenDto.java
@@ -1,0 +1,18 @@
+package com.example.bookshop.auth.dto;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class TokenDto {
+
+
+    private String loginId;
+
+    private String accessToken;
+
+    private String refreshToken;
+
+}

--- a/src/main/java/com/example/bookshop/auth/service/AuthService.java
+++ b/src/main/java/com/example/bookshop/auth/service/AuthService.java
@@ -1,0 +1,13 @@
+package com.example.bookshop.auth.service;
+
+import com.example.bookshop.auth.dto.TokenDto;
+import com.example.bookshop.global.dto.ResultDto;
+import com.example.bookshop.user.dto.UserDto;
+
+public interface AuthService {
+
+
+    UserDto LoginUser(String loginId, String password);
+
+    TokenDto getToken(UserDto userDto);
+}

--- a/src/main/java/com/example/bookshop/auth/service/impl/AuthServiceImpl.java
+++ b/src/main/java/com/example/bookshop/auth/service/impl/AuthServiceImpl.java
@@ -1,0 +1,68 @@
+package com.example.bookshop.auth.service.impl;
+
+import com.example.bookshop.auth.dto.TokenDto;
+import com.example.bookshop.auth.service.AuthService;
+import com.example.bookshop.global.dto.ResultDto;
+import com.example.bookshop.global.exception.CustomException;
+import com.example.bookshop.global.exception.ErrorCode;
+import com.example.bookshop.global.security.TokenProvider;
+import com.example.bookshop.user.dto.UserDto;
+import com.example.bookshop.user.entity.UserEntity;
+import com.example.bookshop.user.repository.UserRepository;
+import com.example.bookshop.user.type.UserType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.example.bookshop.global.exception.ErrorCode.*;
+
+@Service
+@RequiredArgsConstructor
+public class AuthServiceImpl implements AuthService {
+
+    private final PasswordEncoder passwordEncoder;
+
+    private final UserRepository userRepository;
+
+    private final TokenProvider tokenProvider;
+
+
+    /**
+     * 유저 로그인
+     */
+    @Override
+    @Transactional
+    public UserDto LoginUser(String loginId, String password) {
+
+
+        UserEntity user = userRepository.findByLoginId(loginId)
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+        if (!passwordEncoder.matches(password, user.getPassword())) {
+            throw new CustomException(PASSWORD_MISMATCH);
+        }
+
+        if (!user.isEmailAuth()) {
+            throw new CustomException(PROCEED_EMAIL_AUTH);
+        }
+
+
+        return UserDto.fromEntity(user);
+    }
+
+
+    /**
+     * JWT 토큰 발급
+     */
+    @Override
+    public TokenDto getToken(UserDto userDto) {
+
+        String accessToken = tokenProvider.createAccessToken(userDto.getLoginId(), userDto.getEmail(), UserType.valueOf(userDto.getUserType()));
+
+        String refreshToken = tokenProvider.createRefreshToken(userDto.getLoginId());
+
+
+        return new TokenDto(userDto.getLoginId(), accessToken, refreshToken);
+    }
+}

--- a/src/main/java/com/example/bookshop/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/bookshop/global/config/SecurityConfig.java
@@ -1,25 +1,24 @@
 package com.example.bookshop.global.config;
 
 
+import com.example.bookshop.global.security.AuthenticationFilter;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.data.redis.connection.RedisConnectionFactory;
-import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.annotation.web.configurers.CsrfConfigurer;
-import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer.FrameOptionsConfig;
-import org.springframework.security.config.annotation.web.configurers.HttpBasicConfigurer;
-import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final AuthenticationFilter authenticationFilter;
+
 
 
 
@@ -30,9 +29,10 @@ public class SecurityConfig {
                 .formLogin(AbstractHttpConfigurer::disable)
                 .csrf(CsrfConfigurer::disable) // 전체적으로 CSRF 비활성화
                 .authorizeHttpRequests(request -> request
-                        .requestMatchers("/api/user/**").permitAll()  // 정확히 이렇게 되어 있어야 함
+                        .requestMatchers("/api/user/**").permitAll()
                         .anyRequest().authenticated()
-                );
+                )
+                .addFilterBefore(authenticationFilter, UsernamePasswordAuthenticationFilter.class);
         return httpSecurity.build();
     }
 

--- a/src/main/java/com/example/bookshop/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/bookshop/global/exception/ErrorCode.java
@@ -12,6 +12,13 @@ public enum ErrorCode {
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "내부 서버 오류입니다."),
 
 
+    // JWT
+    NOT_FOUND_TOKEN(HttpStatus.UNAUTHORIZED, "토큰이 존재하지 않습니다."),
+    UNSUPPORTED_TOKEN(HttpStatus.UNAUTHORIZED, "지원하지 않는 토큰입니다."),
+    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 토큰입니다. 갱신해주세요."),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
+    ACCESS_DENIED(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
+
     INVALID_INPUT(HttpStatus.BAD_REQUEST, "잘못된 입력입니다."),
     INVALID_PATTERN(HttpStatus.BAD_REQUEST, "잘못된 패턴입니다."),
     PAST_BIRTHDAY(HttpStatus.BAD_REQUEST, "과거 날짜를 입력해주세요."),
@@ -21,7 +28,8 @@ public enum ErrorCode {
     EXISTS_BY_NICKNAME(HttpStatus.BAD_REQUEST, "이미 사용중인 닉네임입니다."),
     EMAIL_NOT_FOUND(HttpStatus.BAD_REQUEST, "이메일을 찾을 수 없습니다."),
     INVALID_AUTH_CODE(HttpStatus.BAD_REQUEST, "유효하지 않은 인증번호입니다."),
-    PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST, "비밀번호와 비밀번호 확인이 일치하지 않습니다.");
+    PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST, "비밀번호와 비밀번호 확인이 일치하지 않습니다."),
+    PROCEED_EMAIL_AUTH(HttpStatus.BAD_REQUEST, "이메일 인증을 진행해주세요.");
 
 
     private final HttpStatus status;

--- a/src/main/java/com/example/bookshop/global/security/AuthenticationFilter.java
+++ b/src/main/java/com/example/bookshop/global/security/AuthenticationFilter.java
@@ -1,0 +1,86 @@
+package com.example.bookshop.global.security;
+
+import com.example.bookshop.global.exception.CustomException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.JwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.ObjectUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class AuthenticationFilter extends OncePerRequestFilter {
+
+
+    public static final String TOKEN_HEADER = "Authorization";
+    public static final String TOKEN_PREFIX = "Bearer ";
+
+    private final TokenProvider tokenProvider;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+
+        String token = resolvedTokenFromRequest(request);
+
+
+        try {
+
+            if (tokenProvider.validateToken(token)) {
+
+                Authentication authentication = tokenProvider.getAuthentication(token);
+
+                if (authentication != null) {
+                    SecurityContextHolder.getContext().setAuthentication(authentication);
+                }
+            }
+
+            filterChain.doFilter(request, response);
+
+        } catch (JwtException | CustomException e) {
+            handleAccessDenied(response, e.getMessage());
+        }
+
+
+    }
+
+
+    private String resolvedTokenFromRequest(HttpServletRequest request) {
+
+        String token = request.getHeader(TOKEN_HEADER);
+
+        if (!ObjectUtils.isEmpty(token) && token.startsWith(TOKEN_PREFIX)) {
+
+            return token.substring(TOKEN_PREFIX.length());
+        }
+
+        return null;
+    }
+
+    private void handleAccessDenied(HttpServletResponse response, String message) throws IOException {
+
+        response.setContentType("application/json");
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        String errorMessage = objectMapper.writeValueAsString(
+                Map.of("statusCode", HttpServletResponse.SC_UNAUTHORIZED,
+                        "errorCode", "UNAUTHORIZED",
+                        "errorMessage",  message)
+        );
+
+
+        response.getWriter().write(errorMessage);
+    }
+
+}

--- a/src/main/java/com/example/bookshop/global/security/TokenProvider.java
+++ b/src/main/java/com/example/bookshop/global/security/TokenProvider.java
@@ -1,0 +1,205 @@
+package com.example.bookshop.global.security;
+
+import com.example.bookshop.global.exception.CustomException;
+import com.example.bookshop.global.service.RedisService;
+import com.example.bookshop.user.service.UserService;
+import com.example.bookshop.user.type.UserType;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+import java.util.Date;
+
+import static com.example.bookshop.global.exception.ErrorCode.*;
+
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class TokenProvider {
+
+    private final RedisService redisService;
+    private final UserService userService;
+    
+    
+    
+    @Value("${spring.jwt.secret}")
+    private String secretKey;
+
+    // Access 토큰 유효시간 30분
+    private static final Long ACCESS_TOKEN_EXPIRED = 1800000L;
+
+
+    // Refresh 토큰 유효시간 1시간
+    private static final long REFRESH_TOKEN_EXPIRED = 3600000L;
+
+    private Key key;
+
+    // JWT 서명용 Key를 애플리케이션 시작 시 단 한 번만 초기화
+    @PostConstruct
+    public void init() {
+        key = Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8));
+    }
+
+
+
+    // 로그인 시 사용할 AccessToken 생성 (사용자 정보 + 30분 유효)
+    public String createAccessToken(String loginId, String email, UserType userType) {
+
+        log.info("Create Access Token");
+
+        String accessToken = generateAccessToken(loginId, email, userType, ACCESS_TOKEN_EXPIRED);
+
+        log.info("Created Access Token");
+
+        return accessToken;
+    }
+
+    // Redis에 저장할 RefreshToken 생성 (로그인 ID만 포함, 1시간 유효)
+    public String createRefreshToken(String loginId) {
+
+        log.info("Create Refresh Token");
+
+        String refreshToken = generateRefreshToken(loginId, REFRESH_TOKEN_EXPIRED);
+
+        log.info("Created Refresh Token");
+
+
+        redisService.setDataExpireMillis("refresh_token:" + loginId, refreshToken, REFRESH_TOKEN_EXPIRED);
+
+
+        return refreshToken;
+    }
+
+    public Authentication getAuthentication(String token) {
+
+        UserDetails userDetails = userService.loadUserByUsername(getUsernameFromToken(token));
+
+        return new UsernamePasswordAuthenticationToken(
+                userDetails, "", userDetails.getAuthorities()
+        );
+    }
+
+
+    public String getUsernameFromToken(String token) {
+
+
+        return parseToken(token).getSubject();
+
+    }
+
+
+    private Claims parseToken(String token) {
+
+        try {
+
+            return Jwts.parserBuilder()
+                    .setSigningKey(key)
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody();
+
+        } catch (ExpiredJwtException e) {
+            return e.getClaims();
+        }
+
+    }
+
+
+
+
+
+
+
+    // AccessToken용 Claims 설정 (loginId = sub, 이메일, userType)
+    private String generateAccessToken(String loginId, String email, UserType userType, long expiredTime) {
+
+        Claims claims = Jwts.claims().setSubject(loginId);
+
+        claims.put("email", email);
+        claims.put("userType", String.valueOf(userType));
+
+
+
+        return returnToken(claims, expiredTime);
+    }
+
+
+    // RefreshToken용 Claims 설정 (loginId = sub)
+    private String generateRefreshToken(String loginId, Long expiredTime) {
+
+        Claims claims = Jwts.claims().setSubject(loginId);
+
+
+        return returnToken(claims, expiredTime);
+
+    }
+
+
+
+
+    private String returnToken(Claims claims, Long expireTime) {
+
+        var now = new Date();
+
+        var expireDate = new Date(now.getTime() + expireTime);
+
+
+        // 설정된 Claims와 서명 키를 바탕으로 JWT 토큰 문자열로 생성하여 반환
+        return Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(now)
+                .setExpiration(expireDate)
+                .signWith(key)
+                .compact();
+
+    }
+
+
+    public boolean validateToken(String token) {
+
+        try {
+
+            Jws<Claims> claims = Jwts.parserBuilder().setSigningKey(key)
+                    .build()
+                    .parseClaimsJws(token);
+
+            return !claims.getBody().getExpiration().before(new Date());
+
+        } catch (IllegalArgumentException e) {
+            throw new JwtException(NOT_FOUND_TOKEN.getMessage());
+        } catch (MalformedJwtException e) {
+            throw new JwtException(UNSUPPORTED_TOKEN.getMessage());
+        } catch (ExpiredJwtException e) {
+            throw new JwtException(EXPIRED_TOKEN.getMessage());
+        } catch (JwtException e) {
+            throw new JwtException(INVALID_TOKEN.getMessage());
+        } catch (CustomException e) {
+            throw e;
+        }
+
+    }
+
+
+    // RefreshToken 갱신 시 검증
+    public void validateRefreshToken(String refreshToken) {
+
+        Claims claims = parseToken(refreshToken);
+
+        if (claims.getExpiration().before(new Date())) {
+            throw new CustomException(EXPIRED_TOKEN);
+        }
+
+    }
+
+
+}

--- a/src/main/java/com/example/bookshop/global/service/MailService.java
+++ b/src/main/java/com/example/bookshop/global/service/MailService.java
@@ -68,7 +68,7 @@ public class MailService {
             mimeMessageHelper.setText(msg, true);
 
             javaMailSender.send(mimeMessage);
-            redisService.setDataExpire(EMAIL_PREFIX + email, code, EMAIL_TOKEN_EXPIRE);
+            redisService.setDataExpireMinutes(EMAIL_PREFIX + email, code, EMAIL_TOKEN_EXPIRE);
 
         } catch (MessagingException e) {
 

--- a/src/main/java/com/example/bookshop/global/service/RedisService.java
+++ b/src/main/java/com/example/bookshop/global/service/RedisService.java
@@ -7,6 +7,7 @@ import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.stereotype.Service;
 
 import java.time.Duration;
+import java.util.concurrent.TimeUnit;
 
 @Service
 @RequiredArgsConstructor
@@ -16,13 +17,23 @@ public class RedisService {
     private final RedisTemplate<String, String> redisTemplate;
 
 
-    public void setDataExpire(String key, String value, Long expiredTime) {
+    public void setDataExpireMinutes(String key, String value, Long expiredTime) {
 
         ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
 
         valueOperations.set(key, value, Duration.ofMinutes(expiredTime));
 
     }
+
+    public void setDataExpireMillis(String key, String value, Long expiredTime) {
+
+        ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
+
+        valueOperations.set(key, value, Duration.ofMillis(expiredTime));
+
+    }
+
+
 
     public String getData(String key) {
 
@@ -36,6 +47,14 @@ public class RedisService {
 
         redisTemplate.delete(key);
 
+    }
+
+    public Long getExpire(String key, TimeUnit milliseconds) {
+        ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
+
+        Long expire = valueOperations.getOperations().getExpire(key, TimeUnit.MILLISECONDS);
+
+        return expire;
     }
 
 }

--- a/src/main/java/com/example/bookshop/user/entity/UserEntity.java
+++ b/src/main/java/com/example/bookshop/user/entity/UserEntity.java
@@ -5,8 +5,14 @@ import com.example.bookshop.global.entity.BaseEntity;
 import com.example.bookshop.user.type.UserType;
 import jakarta.persistence.*;
 import lombok.*;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
 
 import java.time.LocalDate;
+import java.util.Collection;
+import java.util.List;
 
 @Getter
 @Setter
@@ -14,7 +20,7 @@ import java.time.LocalDate;
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
-public class UserEntity extends BaseEntity {
+public class UserEntity extends BaseEntity implements UserDetails {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -54,4 +60,33 @@ public class UserEntity extends BaseEntity {
     }
 
 
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(new SimpleGrantedAuthority(userType.getDescription()));
+    }
+
+    @Override
+    public String getUsername() {
+        return loginId;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return false;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return false;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return false;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return false;
+    }
 }

--- a/src/main/java/com/example/bookshop/user/repository/UserRepository.java
+++ b/src/main/java/com/example/bookshop/user/repository/UserRepository.java
@@ -10,6 +10,9 @@ import java.util.Optional;
 @Repository
 public interface UserRepository extends JpaRepository<UserEntity, Long> {
 
+    Optional<UserEntity> findByLoginId(String loginId);
+
+
     Optional<UserEntity> findByEmail(String email);
 
     boolean existsByLoginId(String loginId);

--- a/src/main/java/com/example/bookshop/user/service/UserService.java
+++ b/src/main/java/com/example/bookshop/user/service/UserService.java
@@ -3,10 +3,11 @@ package com.example.bookshop.user.service;
 import com.example.bookshop.global.dto.CheckDto;
 import com.example.bookshop.global.dto.ResultDto;
 import com.example.bookshop.user.dto.SignUpUserDto;
+import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.stereotype.Service;
 
 @Service
-public interface UserService {
+public interface UserService extends UserDetailsService {
 
     ResultDto<SignUpUserDto.Response> signUpUser(SignUpUserDto.Request signUpUserDto);
 

--- a/src/main/java/com/example/bookshop/user/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/example/bookshop/user/service/impl/UserServiceImpl.java
@@ -9,6 +9,9 @@ import com.example.bookshop.user.entity.UserEntity;
 import com.example.bookshop.user.repository.UserRepository;
 import com.example.bookshop.user.service.UserService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -75,4 +78,10 @@ public class UserServiceImpl implements UserService {
     }
 
 
+    @Override
+    public UserDetails loadUserByUsername(String loginId) throws UsernameNotFoundException {
+
+        return userRepository.findByLoginId(loginId)
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+    }
 }


### PR DESCRIPTION
## ✨ 변경 사항

### 📌 AS-IS
- 로그인 기능 미구현  
- JWT 토큰 발급 로직 미구현

---

### 🚀 TO-BE
- 사용자 로그인 기능 구현  
  - 사용자 검증 및 이메일 인증 여부 확인  
  - 비밀번호 불일치, 이메일 미인증 등의 경우 예외처리

- JWT AccessToken / RefreshToken 발급 기능 구현  
  - `TokenProvider' -> 사용자 검증 후 AccessToken 및 RefreshToken 발급
  - AccessToken 응답 헤더에 포함, 응답 body에 사용자 정보 및 RefreshToken 반환

---

## ✅ 체크리스트

- [x] 로그인 유효성 검사  (비밀번호 검증, 이메일 인증 여부 확인)
- [x] AccessToken / RefreshToken 발급
- [x] RefreshToken Redis 저장 (TTL: 1시간)
- [x] 테스트 코드 작성

