### PR TITLE
[feat] : 사용자 정보 수정 기능 및 토큰 재발급 테스트 구현

### DIFF
--- a/src/main/java/com/example/bookshop/auth/controller/AuthController.java
+++ b/src/main/java/com/example/bookshop/auth/controller/AuthController.java
@@ -70,7 +70,7 @@ public class AuthController {
             throw new CustomException(ErrorCode.NOT_FOUND_TOKEN);
         }
 
-        TokenDto tokenDto = authService.reIssueToken(userEntity.getLoginId(), request);
+        TokenDto tokenDto = authService.reIssueToken(userEntity.getLoginId(), accessToken, refreshToken);
 
         HttpHeaders headers = new HttpHeaders();
 

--- a/src/main/java/com/example/bookshop/auth/service/AuthService.java
+++ b/src/main/java/com/example/bookshop/auth/service/AuthService.java
@@ -12,5 +12,5 @@ public interface AuthService {
 
     TokenDto getToken(UserDto userDto);
 
-    TokenDto reIssueToken(String loginId, HttpServletRequest request);
+    TokenDto reIssueToken(String loginId, String accessToken, String refreshToken);
 }

--- a/src/main/java/com/example/bookshop/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/bookshop/global/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package com.example.bookshop.global.config;
 
 
 import com.example.bookshop.global.security.AuthenticationFilter;
+import com.example.bookshop.global.security.JwtExceptionFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -21,6 +22,7 @@ public class SecurityConfig {
 
     private final AuthenticationFilter authenticationFilter;
 
+    private final JwtExceptionFilter jwtExceptionFilter;
 
 
 
@@ -34,7 +36,8 @@ public class SecurityConfig {
                         .requestMatchers("/api/user/**","/api/auth/login").permitAll()
                         .anyRequest().authenticated()
                 )
-                .addFilterBefore(authenticationFilter, UsernamePasswordAuthenticationFilter.class);
+                .addFilterBefore(authenticationFilter, UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(jwtExceptionFilter, AuthenticationFilter.class);
         return httpSecurity.build();
     }
 

--- a/src/main/java/com/example/bookshop/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/bookshop/global/exception/ErrorCode.java
@@ -30,6 +30,7 @@ public enum ErrorCode {
     EMAIL_NOT_FOUND(HttpStatus.BAD_REQUEST, "이메일을 찾을 수 없습니다."),
     INVALID_AUTH_CODE(HttpStatus.BAD_REQUEST, "유효하지 않은 인증번호입니다."),
     PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST, "비밀번호와 비밀번호 확인이 일치하지 않습니다."),
+    ALREADY_EMAIL_VERIFIED(HttpStatus.BAD_REQUEST, "이미 인증이 완료된 이메일입니다."),
     PROCEED_EMAIL_AUTH(HttpStatus.BAD_REQUEST, "이메일 인증을 진행해주세요.");
 
 

--- a/src/main/java/com/example/bookshop/global/security/AuthenticationFilter.java
+++ b/src/main/java/com/example/bookshop/global/security/AuthenticationFilter.java
@@ -34,8 +34,11 @@ public class AuthenticationFilter extends OncePerRequestFilter {
     private final AntPathMatcher pathMatcher = new AntPathMatcher();
 
     private static final Set<String> WHITELIST = Set.of(
-            "/api/user/login",
-            "/api/auth/**"
+            "/api/auth/login",
+            "/api/user/signup",
+            "/api/user/check-email",
+            "/api/user/send-mail",
+            "/api/user/check-auth-code"
     );
 
 

--- a/src/main/java/com/example/bookshop/global/security/TokenProvider.java
+++ b/src/main/java/com/example/bookshop/global/security/TokenProvider.java
@@ -199,6 +199,10 @@ public class TokenProvider {
     // RefreshToken 갱신 시 검증
     public void validateRefreshToken(String refreshToken) {
 
+        if (refreshToken == null) {
+            throw new CustomException(NOT_FOUND_TOKEN);
+        }
+
         Claims claims = parseToken(refreshToken);
 
         if (claims.getExpiration().before(new Date())) {

--- a/src/main/java/com/example/bookshop/global/service/MailService.java
+++ b/src/main/java/com/example/bookshop/global/service/MailService.java
@@ -35,6 +35,8 @@ public class MailService {
 
     public CheckDto sendAuthMail(String email) {
 
+
+
         String code = createRandomMail();
 
 
@@ -44,6 +46,13 @@ public class MailService {
 
         if (!userRepository.existsByEmail(email)) {
             throw new CustomException(EMAIL_NOT_FOUND);
+        }
+
+        UserEntity userEntity = userRepository.findByEmail(email)
+                .orElseThrow(() -> new CustomException(EMAIL_NOT_FOUND));
+
+        if (userEntity.isEmailAuth()) {
+            throw new CustomException(ALREADY_EMAIL_VERIFIED);
         }
 
         try {

--- a/src/main/java/com/example/bookshop/user/controller/UserController.java
+++ b/src/main/java/com/example/bookshop/user/controller/UserController.java
@@ -4,18 +4,17 @@ package com.example.bookshop.user.controller;
 import com.example.bookshop.global.dto.CheckDto;
 import com.example.bookshop.global.dto.ResultDto;
 import com.example.bookshop.global.service.MailService;
-import com.example.bookshop.user.dto.CheckEmailDto;
-import com.example.bookshop.user.dto.SendMailDto;
-import com.example.bookshop.user.dto.SignUpUserDto;
+import com.example.bookshop.user.dto.*;
+import com.example.bookshop.user.entity.UserEntity;
 import com.example.bookshop.user.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.apache.catalina.User;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -64,6 +63,29 @@ public class UserController {
 
         return ResponseEntity.ok(checkDto);
 
+    }
+
+    @GetMapping("/userinfo")
+    @PreAuthorize("hasAnyRole('USER')")
+    public ResponseEntity<UserDto> getUserInfo(
+            @AuthenticationPrincipal UserEntity userEntity
+    ) {
+
+        userService.getUserInfo(userEntity.getUserId());
+        return ResponseEntity.ok(UserDto.fromEntity(userEntity));
+
+    }
+
+    @PatchMapping("/edit-user")
+    @PreAuthorize("hasAnyRole('USER')")
+    public ResponseEntity<ResultDto<UserDto>> editUser(
+            @AuthenticationPrincipal UserEntity userEntity,
+            @Valid @RequestBody EditUserInfo editUserInfo
+    ) {
+
+        ResultDto<UserDto> userDtoResultDto = userService.editUserInfo(userEntity.getUserId(), editUserInfo);
+
+        return ResponseEntity.ok(userDtoResultDto);
     }
 
 }

--- a/src/main/java/com/example/bookshop/user/dto/EditUserInfo.java
+++ b/src/main/java/com/example/bookshop/user/dto/EditUserInfo.java
@@ -1,0 +1,27 @@
+package com.example.bookshop.user.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class EditUserInfo {
+
+
+    @Email(message = "이메일 형식으로 입력해주세요.")
+    private String email;
+
+    private String nickname;
+
+    @Pattern(regexp = "^01[016789]-\\d{3,4}-\\d{4}$", message = "휴대폰 번호 형식이 올바르지 않습니다.")
+    private String phone;
+
+    private String address;
+
+
+}

--- a/src/main/java/com/example/bookshop/user/dto/UserDto.java
+++ b/src/main/java/com/example/bookshop/user/dto/UserDto.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @Getter
 @AllArgsConstructor
@@ -17,8 +18,6 @@ public class UserDto {
     private Long userId;
 
     private String loginId;
-
-    private String password;
 
     private String email;
 
@@ -32,18 +31,23 @@ public class UserDto {
 
     private String userType;
 
+    private LocalDateTime createdAt;
+
+    private LocalDateTime updatedAt;
+
     public static UserDto fromEntity(UserEntity userEntity) {
 
         return UserDto.builder()
                 .userId(userEntity.getUserId())
                 .loginId(userEntity.getLoginId())
-                .password(userEntity.getPassword())
                 .email(userEntity.getEmail())
                 .birth(userEntity.getBirth())
                 .phone(userEntity.getPhone())
                 .address(userEntity.getAddress())
                 .nickname(userEntity.getNickname())
                 .userType(String.valueOf(userEntity.getUserType()))
+                .createdAt(userEntity.getCreatedAt())
+                .updatedAt(userEntity.getUpdatedAt())
                 .build();
     }
 

--- a/src/main/java/com/example/bookshop/user/dto/UserInfo.java
+++ b/src/main/java/com/example/bookshop/user/dto/UserInfo.java
@@ -1,0 +1,64 @@
+package com.example.bookshop.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+public class UserInfo {
+
+
+    @AllArgsConstructor
+    @Getter
+    public static class Request {
+
+        private String password;
+
+    }
+
+    @Builder
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class Response {
+
+        private String loginId;
+
+        private String email;
+
+        private String nickname;
+
+        private LocalDate birth;
+
+        private String phone;
+
+        private String address;
+
+        private String userType;
+
+        private LocalDateTime createdAt;
+
+        private LocalDateTime updatedAt;
+
+        public static Response fromDto(UserDto userDto) {
+
+            return Response.builder()
+                    .loginId(userDto.getLoginId())
+                    .email(userDto.getEmail())
+                    .nickname(userDto.getNickname())
+                    .birth(userDto.getBirth())
+                    .phone(userDto.getPhone())
+                    .address(userDto.getAddress())
+                    .userType(userDto.getUserType())
+                    .createdAt(userDto.getCreatedAt())
+                    .updatedAt(userDto.getUpdatedAt())
+                    .build();
+
+        }
+
+    }
+
+}

--- a/src/main/java/com/example/bookshop/user/entity/UserEntity.java
+++ b/src/main/java/com/example/bookshop/user/entity/UserEntity.java
@@ -2,6 +2,7 @@ package com.example.bookshop.user.entity;
 
 
 import com.example.bookshop.global.entity.BaseEntity;
+import com.example.bookshop.user.dto.EditUserInfo;
 import com.example.bookshop.user.type.UserType;
 import jakarta.persistence.*;
 import lombok.*;
@@ -51,12 +52,19 @@ public class UserEntity extends BaseEntity implements UserDetails {
     @Column(nullable = false)
     private UserType userType;
 
-    @Builder.Default
+
     private boolean emailAuth = false;
 
 
     public void setEmailAuth() {
         this.emailAuth = true;
+    }
+
+    public void updateUserInfo(EditUserInfo dto) {
+        if (dto.getNickname() != null) this.nickname = dto.getNickname();
+        if (dto.getEmail() != null) this.email = dto.getEmail();
+        if (dto.getPhone() != null) this.phone = dto.getPhone();
+        if (dto.getAddress() != null) this.address = dto.getAddress();
     }
 
 

--- a/src/main/java/com/example/bookshop/user/service/UserService.java
+++ b/src/main/java/com/example/bookshop/user/service/UserService.java
@@ -2,7 +2,9 @@ package com.example.bookshop.user.service;
 
 import com.example.bookshop.global.dto.CheckDto;
 import com.example.bookshop.global.dto.ResultDto;
+import com.example.bookshop.user.dto.EditUserInfo;
 import com.example.bookshop.user.dto.SignUpUserDto;
+import com.example.bookshop.user.dto.UserDto;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.stereotype.Service;
 
@@ -12,4 +14,8 @@ public interface UserService extends UserDetailsService {
     ResultDto<SignUpUserDto.Response> signUpUser(SignUpUserDto.Request signUpUserDto);
 
     CheckDto checkEmail(String email);
+
+    UserDto getUserInfo(Long userId);
+
+    ResultDto<UserDto> editUserInfo(Long userId, EditUserInfo editUserInfo);
 }

--- a/src/main/java/com/example/bookshop/user/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/example/bookshop/user/service/impl/UserServiceImpl.java
@@ -3,14 +3,15 @@ package com.example.bookshop.user.service.impl;
 import com.example.bookshop.global.dto.CheckDto;
 import com.example.bookshop.global.dto.ResultDto;
 import com.example.bookshop.global.exception.CustomException;
+import com.example.bookshop.user.dto.EditUserInfo;
 import com.example.bookshop.user.dto.SignUpUserDto;
 import com.example.bookshop.user.dto.UserDto;
 import com.example.bookshop.user.entity.UserEntity;
 import com.example.bookshop.user.repository.UserRepository;
 import com.example.bookshop.user.service.UserService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -21,6 +22,7 @@ import static com.example.bookshop.global.exception.ErrorCode.*;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class UserServiceImpl implements UserService {
 
     private final UserRepository userRepository;
@@ -61,6 +63,31 @@ public class UserServiceImpl implements UserService {
                 .success(true)
                 .message("사용가능한 이메일 입니다.").build();
 
+    }
+
+    @Override
+    public UserDto getUserInfo(Long userId) {
+
+        log.info("유저 정보 조회: loginId={}", userId);
+        UserEntity userEntity = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+
+        return UserDto.fromEntity(userEntity);
+    }
+
+    @Override
+    public ResultDto<UserDto> editUserInfo(Long userId, EditUserInfo editUserInfo) {
+
+        UserEntity userEntity = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+
+        userEntity.updateUserInfo(editUserInfo);
+
+        UserDto userDto = UserDto.fromEntity(userEntity);
+
+        return ResultDto.of("사용자 정보를 변경하였습니다.", userDto);
     }
 
     private void validationUserInfo(SignUpUserDto.Request request) {

--- a/src/test/java/com/example/bookshop/user/service/impl/UserServiceImplTest.java
+++ b/src/test/java/com/example/bookshop/user/service/impl/UserServiceImplTest.java
@@ -194,6 +194,46 @@ class UserServiceImplTest {
         assertTrue(ttl > 0 && ttl <= 3600000); // 1시간 이내
     }
 
+    @Test
+    void reIssueToken() {
+        // given
+
+        UserDto userDto = authService.LoginUser("testuser", "1111@11");
+        TokenDto token = authService.getToken(userDto);
+
+
+
+        // when
+
+        TokenDto reIssuedToken = authService.reIssueToken(userDto.getLoginId(), token.getAccessToken(), token.getRefreshToken());
+
+
+        // then
+
+        assertNotNull(reIssuedToken.getAccessToken());
+        assertNotNull(reIssuedToken.getRefreshToken());
+
+        assertEquals(redisService.getData("refresh_token:" + userDto.getLoginId()), reIssuedToken.getRefreshToken());
+
+    }
+
+    @Test
+    @DisplayName("토큰 갱신 예외 테스트")
+    void reIssueTokenWithException() {
+        // given
+        UserDto userDto = authService.LoginUser("testuser", "1111@11");
+        TokenDto token = authService.getToken(userDto);
+
+        // Redis에 저장된 토큰 제거
+        redisService.deleteData("refresh_token:" + userDto.getLoginId());
+
+        // when & then
+        assertThrows(CustomException.class, () -> {
+            authService.reIssueToken(userDto.getLoginId(), token.getAccessToken(), token.getRefreshToken());
+        });
+
+    }
+
 
 
 


### PR DESCRIPTION
## ✨ 변경 사항

### 📌 AS-IS
- 사용자 정보 변경 기능 미구현
- 토큰 재발급 관련 예외 테스트 미구현

---

### 🚀 TO-BE
- 사용자 정보 변경 API 구현
  - `@AuthenticationPrincipal`을 통해 로그인된 사용자 정보 기반으로 수정
  - `EditUserInfo` DTO를 이용해 nickname, email, phone, address 필드만 부분 수정

- JWT 토큰 재발급 테스트 및 실패 예외 테스트 작성

---

## ✅ 체크리스트

- [x] 사용자 정보 수정 API 구현
- [x] 토큰 재발급 및 실패 테스트 코드 작성

