### PR TITLE
[feat] : 도서 등록 및 조회, 검색, 카테고리 연관 조회 기능 구현

### DIFF
--- a/src/main/generated/com/example/bookshop/book/entity/QBookEntity.java
+++ b/src/main/generated/com/example/bookshop/book/entity/QBookEntity.java
@@ -1,0 +1,77 @@
+package com.example.bookshop.book.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QBookEntity is a Querydsl query type for BookEntity
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QBookEntity extends EntityPathBase<BookEntity> {
+
+    private static final long serialVersionUID = -1816431376L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QBookEntity bookEntity = new QBookEntity("bookEntity");
+
+    public final com.example.bookshop.global.entity.QBaseEntity _super = new com.example.bookshop.global.entity.QBaseEntity(this);
+
+    public final StringPath author = createString("author");
+
+    public final ListPath<com.example.bookshop.category.entity.BookCategory, com.example.bookshop.category.entity.QBookCategory> bookCategories = this.<com.example.bookshop.category.entity.BookCategory, com.example.bookshop.category.entity.QBookCategory>createList("bookCategories", com.example.bookshop.category.entity.BookCategory.class, com.example.bookshop.category.entity.QBookCategory.class, PathInits.DIRECT2);
+
+    public final NumberPath<Long> bookId = createNumber("bookId", Long.class);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    public final StringPath details = createString("details");
+
+    public final ListPath<BookImageEntity, QBookImageEntity> imagesPath = this.<BookImageEntity, QBookImageEntity>createList("imagesPath", BookImageEntity.class, QBookImageEntity.class, PathInits.DIRECT2);
+
+    public final NumberPath<Integer> price = createNumber("price", Integer.class);
+
+    public final StringPath publisher = createString("publisher");
+
+    public final NumberPath<Integer> quantity = createNumber("quantity", Integer.class);
+
+    public final StringPath thumbnailImagePath = createString("thumbnailImagePath");
+
+    public final StringPath title = createString("title");
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> updatedAt = _super.updatedAt;
+
+    public final com.example.bookshop.user.entity.QUserEntity userEntity;
+
+    public QBookEntity(String variable) {
+        this(BookEntity.class, forVariable(variable), INITS);
+    }
+
+    public QBookEntity(Path<? extends BookEntity> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QBookEntity(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QBookEntity(PathMetadata metadata, PathInits inits) {
+        this(BookEntity.class, metadata, inits);
+    }
+
+    public QBookEntity(Class<? extends BookEntity> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.userEntity = inits.isInitialized("userEntity") ? new com.example.bookshop.user.entity.QUserEntity(forProperty("userEntity")) : null;
+    }
+
+}
+

--- a/src/main/generated/com/example/bookshop/book/entity/QBookImageEntity.java
+++ b/src/main/generated/com/example/bookshop/book/entity/QBookImageEntity.java
@@ -1,0 +1,55 @@
+package com.example.bookshop.book.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QBookImageEntity is a Querydsl query type for BookImageEntity
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QBookImageEntity extends EntityPathBase<BookImageEntity> {
+
+    private static final long serialVersionUID = 928372785L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QBookImageEntity bookImageEntity = new QBookImageEntity("bookImageEntity");
+
+    public final QBookEntity book;
+
+    public final NumberPath<Long> imageId = createNumber("imageId", Long.class);
+
+    public final StringPath imagePath = createString("imagePath");
+
+    public final NumberPath<Integer> sortOrder = createNumber("sortOrder", Integer.class);
+
+    public QBookImageEntity(String variable) {
+        this(BookImageEntity.class, forVariable(variable), INITS);
+    }
+
+    public QBookImageEntity(Path<? extends BookImageEntity> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QBookImageEntity(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QBookImageEntity(PathMetadata metadata, PathInits inits) {
+        this(BookImageEntity.class, metadata, inits);
+    }
+
+    public QBookImageEntity(Class<? extends BookImageEntity> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.book = inits.isInitialized("book") ? new QBookEntity(forProperty("book"), inits.get("book")) : null;
+    }
+
+}
+

--- a/src/main/generated/com/example/bookshop/category/entity/QBookCategory.java
+++ b/src/main/generated/com/example/bookshop/category/entity/QBookCategory.java
@@ -1,0 +1,54 @@
+package com.example.bookshop.category.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QBookCategory is a Querydsl query type for BookCategory
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QBookCategory extends EntityPathBase<BookCategory> {
+
+    private static final long serialVersionUID = -1110657696L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QBookCategory bookCategory = new QBookCategory("bookCategory");
+
+    public final com.example.bookshop.book.entity.QBookEntity bookEntity;
+
+    public final QCategoryEntity categoryEntity;
+
+    public final NumberPath<Long> productCategoryId = createNumber("productCategoryId", Long.class);
+
+    public QBookCategory(String variable) {
+        this(BookCategory.class, forVariable(variable), INITS);
+    }
+
+    public QBookCategory(Path<? extends BookCategory> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QBookCategory(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QBookCategory(PathMetadata metadata, PathInits inits) {
+        this(BookCategory.class, metadata, inits);
+    }
+
+    public QBookCategory(Class<? extends BookCategory> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.bookEntity = inits.isInitialized("bookEntity") ? new com.example.bookshop.book.entity.QBookEntity(forProperty("bookEntity"), inits.get("bookEntity")) : null;
+        this.categoryEntity = inits.isInitialized("categoryEntity") ? new QCategoryEntity(forProperty("categoryEntity"), inits.get("categoryEntity")) : null;
+    }
+
+}
+

--- a/src/main/generated/com/example/bookshop/category/entity/QCategoryEntity.java
+++ b/src/main/generated/com/example/bookshop/category/entity/QCategoryEntity.java
@@ -1,0 +1,59 @@
+package com.example.bookshop.category.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QCategoryEntity is a Querydsl query type for CategoryEntity
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QCategoryEntity extends EntityPathBase<CategoryEntity> {
+
+    private static final long serialVersionUID = -1954646374L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QCategoryEntity categoryEntity = new QCategoryEntity("categoryEntity");
+
+    public final NumberPath<Long> categoryId = createNumber("categoryId", Long.class);
+
+    public final StringPath categoryName = createString("categoryName");
+
+    public final ListPath<CategoryEntity, QCategoryEntity> children = this.<CategoryEntity, QCategoryEntity>createList("children", CategoryEntity.class, QCategoryEntity.class, PathInits.DIRECT2);
+
+    public final NumberPath<Integer> depth = createNumber("depth", Integer.class);
+
+    public final QCategoryEntity parent;
+
+    public final ListPath<BookCategory, QBookCategory> productCategories = this.<BookCategory, QBookCategory>createList("productCategories", BookCategory.class, QBookCategory.class, PathInits.DIRECT2);
+
+    public QCategoryEntity(String variable) {
+        this(CategoryEntity.class, forVariable(variable), INITS);
+    }
+
+    public QCategoryEntity(Path<? extends CategoryEntity> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QCategoryEntity(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QCategoryEntity(PathMetadata metadata, PathInits inits) {
+        this(CategoryEntity.class, metadata, inits);
+    }
+
+    public QCategoryEntity(Class<? extends CategoryEntity> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.parent = inits.isInitialized("parent") ? new QCategoryEntity(forProperty("parent"), inits.get("parent")) : null;
+    }
+
+}
+

--- a/src/main/generated/com/example/bookshop/global/entity/QBaseEntity.java
+++ b/src/main/generated/com/example/bookshop/global/entity/QBaseEntity.java
@@ -1,0 +1,39 @@
+package com.example.bookshop.global.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QBaseEntity is a Querydsl query type for BaseEntity
+ */
+@Generated("com.querydsl.codegen.DefaultSupertypeSerializer")
+public class QBaseEntity extends EntityPathBase<BaseEntity> {
+
+    private static final long serialVersionUID = 855841170L;
+
+    public static final QBaseEntity baseEntity = new QBaseEntity("baseEntity");
+
+    public final DateTimePath<java.time.LocalDateTime> createdAt = createDateTime("createdAt", java.time.LocalDateTime.class);
+
+    public final DateTimePath<java.time.LocalDateTime> updatedAt = createDateTime("updatedAt", java.time.LocalDateTime.class);
+
+    public QBaseEntity(String variable) {
+        super(BaseEntity.class, forVariable(variable));
+    }
+
+    public QBaseEntity(Path<? extends BaseEntity> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QBaseEntity(PathMetadata metadata) {
+        super(BaseEntity.class, metadata);
+    }
+
+}
+

--- a/src/main/generated/com/example/bookshop/user/entity/QUserEntity.java
+++ b/src/main/generated/com/example/bookshop/user/entity/QUserEntity.java
@@ -1,0 +1,67 @@
+package com.example.bookshop.user.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QUserEntity is a Querydsl query type for UserEntity
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QUserEntity extends EntityPathBase<UserEntity> {
+
+    private static final long serialVersionUID = 728199348L;
+
+    public static final QUserEntity userEntity = new QUserEntity("userEntity");
+
+    public final com.example.bookshop.global.entity.QBaseEntity _super = new com.example.bookshop.global.entity.QBaseEntity(this);
+
+    public final StringPath address = createString("address");
+
+    public final DatePath<java.time.LocalDate> birth = createDate("birth", java.time.LocalDate.class);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    public final DateTimePath<java.time.LocalDateTime> deletedAt = createDateTime("deletedAt", java.time.LocalDateTime.class);
+
+    public final StringPath email = createString("email");
+
+    public final BooleanPath emailAuth = createBoolean("emailAuth");
+
+    public final StringPath loginId = createString("loginId");
+
+    public final StringPath nickname = createString("nickname");
+
+    public final StringPath password = createString("password");
+
+    public final StringPath phone = createString("phone");
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> updatedAt = _super.updatedAt;
+
+    public final NumberPath<Long> userId = createNumber("userId", Long.class);
+
+    public final EnumPath<com.example.bookshop.user.type.UserState> userState = createEnum("userState", com.example.bookshop.user.type.UserState.class);
+
+    public final EnumPath<com.example.bookshop.user.type.UserType> userType = createEnum("userType", com.example.bookshop.user.type.UserType.class);
+
+    public QUserEntity(String variable) {
+        super(UserEntity.class, forVariable(variable));
+    }
+
+    public QUserEntity(Path<? extends UserEntity> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QUserEntity(PathMetadata metadata) {
+        super(UserEntity.class, metadata);
+    }
+
+}
+

--- a/src/main/java/com/example/bookshop/book/controller/BookController.java
+++ b/src/main/java/com/example/bookshop/book/controller/BookController.java
@@ -1,0 +1,88 @@
+package com.example.bookshop.book.controller;
+
+import com.example.bookshop.book.dto.BookDto;
+import com.example.bookshop.book.dto.CreateBookDto;
+import com.example.bookshop.book.service.BookService;
+import com.example.bookshop.global.dto.ResultDto;
+import com.example.bookshop.user.entity.UserEntity;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.List;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/book")
+public class BookController {
+
+    private final BookService bookService;
+
+    @PostMapping(value = "/create", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @PreAuthorize("hasAnyRole('USER')")
+    public ResponseEntity<ResultDto<CreateBookDto.Response>> createBook(
+            @RequestPart("request") @Valid CreateBookDto.Request request,
+            @RequestPart("thumbnail") MultipartFile thumbnailImagePath,
+            @RequestPart("images") List<MultipartFile> detailImagesPaths,
+            @AuthenticationPrincipal UserEntity userEntity
+            ) throws IOException {
+
+
+
+        ResultDto<CreateBookDto.Response> book = bookService.createBook(request, thumbnailImagePath, detailImagesPaths, userEntity.getUserId());
+
+
+        return ResponseEntity.ok(book);
+    }
+
+    @GetMapping("/detail/{bookId}")
+    public ResponseEntity<ResultDto<BookDto>> getBookDetails(
+            @PathVariable Long bookId
+    ) {
+
+        ResultDto<BookDto> bookDetails = bookService.getBookDetails(bookId);
+
+        return ResponseEntity.ok(bookDetails);
+
+    }
+
+    @GetMapping("/search")
+    public ResponseEntity<ResultDto<Page<BookDto>>> searchBook(
+            @RequestParam(required = false) String keyword,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+
+        PageRequest pageRequest = PageRequest.of(page, size);
+
+        ResultDto<Page<BookDto>> pageResultDto = bookService.searchBook(keyword, pageRequest);
+
+        return ResponseEntity.ok(pageResultDto);
+
+    }
+
+    @GetMapping("/search/category/{categoryId}")
+    public ResponseEntity<ResultDto<Page<BookDto>>> searchCategory(
+            @PathVariable Long categoryId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        PageRequest pageRequest = PageRequest.of(page, size);
+
+        ResultDto<Page<BookDto>> pageResultDto = bookService.searchCategory(categoryId, pageRequest);
+
+        return ResponseEntity.ok(pageResultDto);
+
+    }
+
+
+}

--- a/src/main/java/com/example/bookshop/book/dto/BookDto.java
+++ b/src/main/java/com/example/bookshop/book/dto/BookDto.java
@@ -1,0 +1,79 @@
+package com.example.bookshop.book.dto;
+
+
+import com.example.bookshop.book.entity.BookEntity;
+import com.example.bookshop.book.entity.BookImageEntity;
+import com.example.bookshop.user.entity.UserEntity;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class BookDto {
+
+    private Long bookId;
+
+    private String title;
+
+    private String author;
+
+    private String publisher;
+
+    private String details;
+
+    private Integer price;
+
+    private Integer quantity;
+
+    private String thumbnailImagePath;
+
+    private List<BookImageDto> imagesPath;
+
+    private Long userId;
+
+    private List<Long> categoryIds;
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime updatedAt;
+
+    public static BookDto fromEntity(BookEntity bookEntity) {
+
+
+        List<Long> categoryIds = bookEntity.getBookCategories().stream()
+                .map(bookCategory -> bookCategory.getCategoryEntity()
+                        .getCategoryId())
+                .toList();
+
+        List<BookImageDto> imagePaths = bookEntity.getImagesPath().stream()
+                .map(BookImageDto::fromEntity)
+                .collect(Collectors.toList());
+
+
+        return BookDto.builder()
+                .bookId(bookEntity.getBookId())
+                .title(bookEntity.getTitle())
+                .author(bookEntity.getAuthor())
+                .publisher(bookEntity.getPublisher())
+                .details(bookEntity.getDetails())
+                .price(bookEntity.getPrice())
+                .quantity(bookEntity.getQuantity())
+                .thumbnailImagePath(bookEntity.getThumbnailImagePath())
+                .imagesPath(imagePaths)
+                .userId(bookEntity.getUserEntity().getUserId())
+                .categoryIds(categoryIds)
+                .createdAt(bookEntity.getCreatedAt())
+                .updatedAt(bookEntity.getUpdatedAt())
+                .build();
+    }
+
+
+}

--- a/src/main/java/com/example/bookshop/book/dto/BookImageDto.java
+++ b/src/main/java/com/example/bookshop/book/dto/BookImageDto.java
@@ -1,0 +1,32 @@
+package com.example.bookshop.book.dto;
+
+import com.example.bookshop.book.entity.BookEntity;
+import com.example.bookshop.book.entity.BookImageEntity;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class BookImageDto {
+
+    private String imagePath;
+
+    private int sortOrder;
+
+    public static BookImageEntity toEntity(BookImageDto dto, BookEntity book) {
+        return BookImageEntity.builder()
+                .imagePath(dto.getImagePath())
+                .sortOrder(dto.getSortOrder())
+                .book(book)
+                .build();
+    }
+
+    public static BookImageDto fromEntity(BookImageEntity entity) {
+        return BookImageDto.builder()
+                .imagePath(entity.getImagePath())
+                .sortOrder(entity.getSortOrder())
+                .build();
+    }
+}

--- a/src/main/java/com/example/bookshop/book/dto/CreateBookDto.java
+++ b/src/main/java/com/example/bookshop/book/dto/CreateBookDto.java
@@ -47,10 +47,11 @@ public class CreateBookDto {
 
         private List<BookImageDto> imagesPath;
 
-        private UserEntity userEntity;
+        private List<Long> categoryIds;
 
 
         public static BookEntity toEntity(Request request) {
+
 
 
             BookEntity bookEntity = BookEntity.builder()
@@ -61,7 +62,6 @@ public class CreateBookDto {
                     .price(request.getPrice())
                     .quantity(request.getQuantity())
                     .thumbnailImagePath(request.getThumbnailImagePath())
-                    .userEntity(request.getUserEntity())
                     .build();
 
             List<BookImageEntity> imagesPaths = request.getImagesPath().stream()
@@ -97,15 +97,15 @@ public class CreateBookDto {
 
         private List<BookImageDto> imagePath;
 
+        private List<Long> categoryIds;
+
         private LocalDateTime createdAt;
 
         private LocalDateTime updatedAt;
 
         public static Response fromDto(BookDto bookDto) {
 
-            List<BookImageDto> imagesPaths = bookDto.getImagesPath().stream()
-                    .map(BookImageDto::fromEntity)
-                    .toList();
+
 
 
             return Response.builder()
@@ -116,7 +116,8 @@ public class CreateBookDto {
                     .price(bookDto.getPrice())
                     .quantity(bookDto.getQuantity())
                     .thumbnailImagePath(bookDto.getThumbnailImagePath())
-                    .imagePath(imagesPaths)
+                    .imagePath(bookDto.getImagesPath())
+                    .categoryIds(bookDto.getCategoryIds())
                     .createdAt(bookDto.getCreatedAt())
                     .updatedAt(bookDto.getUpdatedAt())
                     .build();

--- a/src/main/java/com/example/bookshop/book/entity/BookEntity.java
+++ b/src/main/java/com/example/bookshop/book/entity/BookEntity.java
@@ -1,0 +1,58 @@
+package com.example.bookshop.book.entity;
+
+
+import com.example.bookshop.category.entity.BookCategory;
+import com.example.bookshop.global.entity.BaseEntity;
+import com.example.bookshop.user.entity.UserEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.List;
+
+@Entity
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class BookEntity extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long bookId;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(nullable = false)
+    private String author;
+
+    @Column(nullable = false)
+    private String details;
+
+    @Column(nullable = false)
+    private String publisher;
+
+    @Column(nullable = false)
+    private Integer price;
+
+    @Column(nullable = false)
+    private Integer quantity;
+
+    @Column(nullable = false)
+    private String thumbnailImagePath;
+
+    @OneToMany(mappedBy = "book", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<BookImageEntity> imagesPath;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private UserEntity userEntity;
+
+    @OneToMany(mappedBy = "bookEntity", cascade = CascadeType.ALL, orphanRemoval = true)
+    List<BookCategory> bookCategories;
+
+
+
+
+}

--- a/src/main/java/com/example/bookshop/book/entity/BookImageEntity.java
+++ b/src/main/java/com/example/bookshop/book/entity/BookImageEntity.java
@@ -1,0 +1,29 @@
+package com.example.bookshop.book.entity;
+
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class BookImageEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long imageId;
+
+    @Column(nullable = false)
+    private String imagePath;
+
+    @Column(nullable = false)
+    private int sortOrder;
+
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "book_id")
+    private BookEntity book;
+}

--- a/src/main/java/com/example/bookshop/book/repository/BookQueryRepository.java
+++ b/src/main/java/com/example/bookshop/book/repository/BookQueryRepository.java
@@ -1,0 +1,110 @@
+package com.example.bookshop.book.repository;
+
+
+import com.example.bookshop.book.dto.BookDto;
+import com.example.bookshop.book.entity.BookEntity;
+import com.example.bookshop.book.entity.QBookEntity;
+import com.example.bookshop.category.entity.QBookCategory;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+import org.springframework.util.StringUtils;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Repository
+@RequiredArgsConstructor
+public class BookQueryRepository {
+
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    public Page<BookDto> searchByKeyword(String keyword, Pageable pageable) {
+
+
+        QBookEntity qBookEntity = QBookEntity.bookEntity;
+
+
+        BooleanBuilder builder = getKeywordCondition(keyword, qBookEntity);
+
+        List<BookEntity> content = jpaQueryFactory
+                .select(qBookEntity)
+                .from(qBookEntity)
+                .where(builder)
+                .orderBy(qBookEntity.createdAt.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        List<BookDto> bookDto = content.stream()
+                .map(BookDto::fromEntity)
+                .collect(Collectors.toList());
+
+        Long total = Optional.ofNullable(
+                jpaQueryFactory
+                        .select(qBookEntity.count())
+                        .from(qBookEntity)
+                        .where(builder)
+                        .fetchOne()).orElse(0L);
+
+        return new PageImpl<>(bookDto, pageable, total);
+
+
+    }
+
+
+    public Page<BookDto> searchCategory(Long categoryId, Pageable pageable) {
+
+        QBookEntity qBookEntity = QBookEntity.bookEntity;
+        QBookCategory qBookCategory = QBookCategory.bookCategory;
+
+        List<BookEntity> content = jpaQueryFactory
+                .select(qBookEntity)
+                .from(qBookEntity)
+                .join(qBookEntity.bookCategories, qBookCategory)
+                .fetchJoin()
+                .where(qBookCategory.categoryEntity.categoryId.eq(categoryId))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .orderBy(qBookEntity.createdAt.desc())
+                .fetch();
+
+        List<BookDto> result = content.stream()
+                .map(BookDto::fromEntity)
+                .collect(Collectors.toList());
+
+        Long total = jpaQueryFactory
+                .select(qBookEntity.count())
+                .from(qBookEntity)
+                .join(qBookEntity.bookCategories, qBookCategory)
+                .where(qBookCategory.categoryEntity.categoryId.eq(categoryId))
+                .fetchOne();
+
+        return new PageImpl<>(result, pageable, total);
+
+
+    }
+
+    private static BooleanBuilder getKeywordCondition(String keyword, QBookEntity qBookEntity) {
+        // 동적 where 조건 구성
+        BooleanBuilder builder = new BooleanBuilder();
+
+
+        if (StringUtils.hasText(keyword)) {
+
+            builder.or(qBookEntity.title.containsIgnoreCase(keyword));
+            builder.or(qBookEntity.author.containsIgnoreCase(keyword));
+            builder.or(qBookEntity.publisher.containsIgnoreCase(keyword));
+
+        }
+        return builder;
+    }
+
+
+}

--- a/src/main/java/com/example/bookshop/book/repository/BookRepository.java
+++ b/src/main/java/com/example/bookshop/book/repository/BookRepository.java
@@ -1,0 +1,12 @@
+package com.example.bookshop.book.repository;
+
+import com.example.bookshop.book.entity.BookEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface BookRepository extends JpaRepository<BookEntity, Long> {
+
+    boolean existsByTitle(String title);
+
+}

--- a/src/main/java/com/example/bookshop/book/service/BookService.java
+++ b/src/main/java/com/example/bookshop/book/service/BookService.java
@@ -1,0 +1,26 @@
+package com.example.bookshop.book.service;
+
+
+import com.example.bookshop.book.dto.BookDto;
+import com.example.bookshop.book.dto.CreateBookDto;
+import com.example.bookshop.global.dto.ResultDto;
+import com.example.bookshop.user.entity.UserEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.List;
+
+public interface BookService {
+
+
+    ResultDto<CreateBookDto.Response> createBook(CreateBookDto.Request request, MultipartFile thumbnailImagePath, List<MultipartFile> imagesPaths, Long userId) throws IOException;
+
+    ResultDto<BookDto> getBookDetails(Long bookId);
+
+    ResultDto<Page<BookDto>> searchBook(String keyword, Pageable pageable);
+
+
+    ResultDto<Page<BookDto>> searchCategory(Long categoryId, Pageable pageable);
+}

--- a/src/main/java/com/example/bookshop/book/service/impl/BookServiceImpl.java
+++ b/src/main/java/com/example/bookshop/book/service/impl/BookServiceImpl.java
@@ -1,0 +1,220 @@
+package com.example.bookshop.book.service.impl;
+
+import com.example.bookshop.book.dto.BookDto;
+import com.example.bookshop.book.dto.BookImageDto;
+import com.example.bookshop.book.dto.CreateBookDto;
+import com.example.bookshop.book.entity.BookEntity;
+import com.example.bookshop.book.repository.BookQueryRepository;
+import com.example.bookshop.book.repository.BookRepository;
+import com.example.bookshop.book.service.BookService;
+import com.example.bookshop.category.entity.BookCategory;
+import com.example.bookshop.category.entity.CategoryEntity;
+import com.example.bookshop.category.repository.CategoryRepository;
+import com.example.bookshop.global.dto.ResultDto;
+import com.example.bookshop.global.exception.CustomException;
+import com.example.bookshop.user.entity.UserEntity;
+import com.example.bookshop.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import static com.example.bookshop.global.exception.ErrorCode.*;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class BookServiceImpl implements BookService {
+
+    private final BookRepository bookRepository;
+
+    private final CategoryRepository categoryRepository;
+
+    private final UserRepository userRepository;
+
+    private final BookQueryRepository  bookQueryRepository;
+
+    // 썸네일 이미지를 저장할 디렉터리 경로
+    private static final String THUMBNAIL_DIR = "uploads/book-thumbnail/";
+
+    // 상세 이미지를 저장할 디렉터리 경로
+    private static final String DETAIL_IMAGE_DIR = "uploads/book-detail/";
+
+
+    /**
+     * 도서 등록 API
+     */
+    @Override
+    @Transactional
+    public ResultDto<CreateBookDto.Response> createBook(
+            CreateBookDto.Request request,
+            MultipartFile thumbnailImagePath,                // 썸네일 이미지 파일
+            List<MultipartFile> imagesPaths,                 // 상세 이미지 리스트
+            Long userId
+    ) throws IOException {
+
+        log.info("[도서 등록] 제목: {}", request.getTitle());
+
+
+        UserEntity userEntity = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+
+        // 등록된 도서 확인
+        if (bookRepository.existsByTitle(request.getTitle())) {
+            throw new CustomException(ALREADY_CREATE_BOOK);
+        }
+
+
+        // 썸네일 이미지 파일을 저장하고, 저장된 파일명을 경로로 받음
+        String thumbnailFileName = saveImage(thumbnailImagePath, THUMBNAIL_DIR);
+
+        // DTO에 썸네일 경로 설정
+        request.setThumbnailImagePath(thumbnailFileName);
+
+        // 상세 이미지 정보를 담을 리스트
+        List<BookImageDto> imageDtos = new ArrayList<>();
+
+        int sortOrder = 0;
+
+        // 상세 이미지 리스트 반복 처리
+        for (MultipartFile imagePath : imagesPaths) {
+            String detailImagePaths = saveImage(imagePath, DETAIL_IMAGE_DIR);
+            imageDtos.add(new BookImageDto(detailImagePaths, sortOrder++));
+        }
+
+        // DTO에 상세 이미지 경로들 설정
+        request.setImagesPath(imageDtos);
+
+        // DTO → Entity 변환
+        BookEntity bookEntity = CreateBookDto.Request.toEntity(request);
+
+
+        List<CategoryEntity> categories = categoryRepository.findAllById(request.getCategoryIds());
+
+        if (categories.isEmpty()) {
+            throw new CustomException(NOT_FOUND_CATEGORY);
+        }
+        List<BookCategory> bookCategories = categories.stream()
+                        .map(category -> BookCategory.builder()
+                                .bookEntity(bookEntity)
+                                .categoryEntity(category)
+                                .build())
+                .collect(Collectors.toList());
+
+        bookEntity.setBookCategories(bookCategories);
+
+        bookEntity.setUserEntity(userEntity);
+
+        BookEntity savedBook = bookRepository.save(bookEntity);
+
+        log.info("[도서 등록 완료] 제목: {}", savedBook.getTitle());
+
+        // 저장된 결과를 응답 형태로 변환
+        return ResultDto.of(
+                "도서 등록에 성공하였습니다.",
+                CreateBookDto.Response.fromDto(BookDto.fromEntity(savedBook))
+        );
+    }
+
+
+    /**
+     * 도서 상세 조회 API
+     */
+    @Override
+    @Transactional
+    public ResultDto<BookDto> getBookDetails(Long bookId) {
+
+
+        BookEntity bookEntity = bookRepository.findById(bookId)
+                .orElseThrow(() -> new CustomException(NOT_FOUND_BOOK));
+
+
+
+        return ResultDto.of("도서 상세조회 완료.", BookDto.fromEntity(bookEntity));
+
+    }
+
+    /**
+     * 도서 검색 API
+     */
+    @Override
+    public ResultDto<Page<BookDto>> searchBook(String keyword, Pageable pageable) {
+
+
+        Page<BookDto> result = bookQueryRepository.searchByKeyword(keyword, pageable);
+
+        if (result.isEmpty()) {
+            throw new CustomException(NOT_FOUND_BOOK);
+        }
+
+        return ResultDto.of("도서 검색이 완료되었습니다.", result);
+    }
+
+    @Override
+    public ResultDto<Page<BookDto>> searchCategory(Long categoryId, Pageable pageable) {
+
+        Page<BookDto> bookDtos = bookQueryRepository.searchCategory(categoryId, pageable);
+
+        if (bookDtos.isEmpty()) {
+            throw new CustomException(NOT_FOUND_CATEGORY);
+        }
+
+
+        return ResultDto.of("카테고리 별 도서 조회 완료", bookDtos);
+    }
+
+
+    /**
+     * 이미지 파일을 지정된 경로에 저장하고 저장 경로를 문자열로 반환하는 메서드
+     */
+    private String saveImage(MultipartFile file, String uploadDir) throws IOException {
+        if (file == null || file.isEmpty()) {
+            log.error("이미지 업로드 실패 - 이미지가 존재하지 않습니다.");
+            throw new CustomException(IMAGE_NOT_FOUND);
+        }
+
+        try {
+            // UUID: 파일명 중복 방지를 위해 고유값 생성
+            String uuid = UUID.randomUUID().toString();
+
+            // 공백 있는 파일명은 오류 방지를 위해 "_"로 변환
+            String fileName = uuid + "_" + file.getOriginalFilename().replaceAll(" ", "_");
+
+            // 업로드 경로를 절대경로로 변환 (보안 및 정합성)
+            Path uploadPath = Paths.get(uploadDir).toAbsolutePath().normalize();
+
+            // 경로가 없다면 폴더 생성
+            Files.createDirectories(uploadPath);
+
+            // 최종 저장 경로 구성
+            Path filePath = uploadPath.resolve(fileName);
+
+            // 실제 파일 저장 (Spring 제공 메서드)
+            file.transferTo(filePath.toFile());
+
+
+            // 저장된 경로 문자열 반환 (DB 저장용)
+            return uploadDir + fileName;
+        } catch (IOException e) {
+            log.error("IOException : {}", e.getMessage());
+            throw new CustomException(IMAGE_UPLOAD_FAIL);
+        }
+
+
+
+    }
+}
+

--- a/src/main/java/com/example/bookshop/category/entity/BookCategory.java
+++ b/src/main/java/com/example/bookshop/category/entity/BookCategory.java
@@ -3,16 +3,16 @@ package com.example.bookshop.category.entity;
 import com.example.bookshop.book.entity.BookEntity;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.awt.print.Book;
 
 @Entity
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-public class ProductCategory {
+@Builder
+public class BookCategory {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/example/bookshop/category/entity/CategoryEntity.java
+++ b/src/main/java/com/example/bookshop/category/entity/CategoryEntity.java
@@ -31,7 +31,7 @@ public class CategoryEntity {
     private List<CategoryEntity> children = new ArrayList<>();
 
     @OneToMany(mappedBy = "categoryEntity", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<ProductCategory> productCategories = new ArrayList<>();
+    private List<BookCategory> productCategories = new ArrayList<>();
 
 
     /**

--- a/src/main/java/com/example/bookshop/global/config/QueryDslConfig.java
+++ b/src/main/java/com/example/bookshop/global/config/QueryDslConfig.java
@@ -1,0 +1,22 @@
+package com.example.bookshop.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/com/example/bookshop/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/bookshop/global/config/SecurityConfig.java
@@ -34,6 +34,7 @@ public class SecurityConfig {
                 .csrf(CsrfConfigurer::disable) // 전체적으로 CSRF 비활성화
                 .authorizeHttpRequests(request -> request
                         .requestMatchers("/api/user/**","/api/auth/login").permitAll()
+                        .requestMatchers("/api/book/detail/**", "api/book/search/**").permitAll()
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(authenticationFilter, UsernamePasswordAuthenticationFilter.class)

--- a/src/main/java/com/example/bookshop/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/bookshop/global/exception/ErrorCode.java
@@ -39,6 +39,7 @@ public enum ErrorCode {
 
     // book
     ALREADY_CREATE_BOOK(HttpStatus.BAD_REQUEST, "이미 등록된 책입니다."),
+    NOT_FOUND_BOOK(HttpStatus.BAD_REQUEST, "도서를 찾을 수 없습니다."),
     IMAGE_NOT_FOUND(HttpStatus.BAD_REQUEST, "이미지를 찾을 수 없습니다."),
     IMAGE_UPLOAD_FAIL(HttpStatus.INTERNAL_SERVER_ERROR,"이미지 업로드에 실패했습니다."),
 

--- a/src/main/java/com/example/bookshop/global/security/AuthenticationFilter.java
+++ b/src/main/java/com/example/bookshop/global/security/AuthenticationFilter.java
@@ -45,7 +45,10 @@ public class AuthenticationFilter extends OncePerRequestFilter {
             "/api/user/signup",
             "/api/user/check-email",
             "/api/user/send-mail",
-            "/api/user/check-auth-code"
+            "/api/user/check-auth-code",
+            "/api/book/detail/**",
+            "/api/book/search",
+            "/api/book/search/category/**"
     );
 
 


### PR DESCRIPTION
## ✨ 변경 사항

### 📌 AS-IS  
- 도서 등록 및 조회, 검색, 카테고리 연관 조회 기능 미구현  

---

### 🚀 TO-BE  

- ✅ **도서 등록 기능 구현**
  - 썸네일, 상세 이미지 업로드 및 저장
  - 사용자 ID 기반 등록
  - 다대다 관계(`BookCategory`)로 카테고리와 연결

- ✅ **도서 상세 조회 기능 구현**
  - 단일 도서 ID로 도서 상세 정보 응답
  - 연관된 이미지, 카테고리, 등록자 ID 포함

- ✅ **도서 검색 기능(QueryDSL 기반) 구현**
  - 키워드로 도서 제목, 저자, 출판사 조건 검색
  - BooleanBuilder를 이용한 동적 where 조건 구성
  - 페이징 처리 및 정렬 지원

- ✅ **카테고리별 도서 조회 기능 구현**
  - 중간 테이블(`BookCategory`) 통해 연관 도서 조회
  - QueryDSL로 페치 조인 최적화 처리

---

## ✅ 체크리스트

- [x] 도서 등록 시 썸네일 및 상세 이미지 업로드
- [x] 사용자 ID를 통한 도서 등록 및 매핑 처리
- [x] 연관 카테고리(BookCategory)를 통한 다대다 연결 처리
- [x] 상세 조회 시 이미지, 등록자 ID, 카테고리 목록 포함
- [x] QueryDSL 기반 키워드 검색 API 구현
- [x] 카테고리 ID 기반 연관 도서 조회 API 구현

---
