### PR TITLE
[feat] : 도서 수정 및 삭제 기능 구현

### DIFF
--- a/src/main/generated/com/example/bookshop/book/entity/QBookEntity.java
+++ b/src/main/generated/com/example/bookshop/book/entity/QBookEntity.java
@@ -30,6 +30,8 @@ public class QBookEntity extends EntityPathBase<BookEntity> {
 
     public final NumberPath<Long> bookId = createNumber("bookId", Long.class);
 
+    public final EnumPath<com.example.bookshop.book.type.BookStatus> bookStatus = createEnum("bookStatus", com.example.bookshop.book.type.BookStatus.class);
+
     //inherited
     public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
 

--- a/src/main/java/com/example/bookshop/book/controller/BookController.java
+++ b/src/main/java/com/example/bookshop/book/controller/BookController.java
@@ -2,6 +2,7 @@ package com.example.bookshop.book.controller;
 
 import com.example.bookshop.book.dto.BookDto;
 import com.example.bookshop.book.dto.CreateBookDto;
+import com.example.bookshop.book.dto.UpdateBookDto;
 import com.example.bookshop.book.service.BookService;
 import com.example.bookshop.global.dto.ResultDto;
 import com.example.bookshop.user.entity.UserEntity;
@@ -81,6 +82,22 @@ public class BookController {
         ResultDto<Page<BookDto>> pageResultDto = bookService.searchCategory(categoryId, pageRequest);
 
         return ResponseEntity.ok(pageResultDto);
+
+    }
+
+    @PatchMapping("/update")
+    @PreAuthorize("hasAnyRole('USER')")
+    public ResponseEntity<ResultDto<BookDto>> updateBook (
+            @RequestPart("request") UpdateBookDto request,
+            @RequestPart("thumbnail") MultipartFile thumbnailImagePath,
+            @RequestPart("images") List<MultipartFile> detailImagesPaths,
+            @AuthenticationPrincipal UserEntity userEntity
+
+    ) throws IOException {
+
+        ResultDto<BookDto> bookDtoResultDto = bookService.updateBook(request, thumbnailImagePath, detailImagesPaths, userEntity.getUserId());
+
+        return ResponseEntity.ok(bookDtoResultDto);
 
     }
 

--- a/src/main/java/com/example/bookshop/book/dto/BookDto.java
+++ b/src/main/java/com/example/bookshop/book/dto/BookDto.java
@@ -33,6 +33,8 @@ public class BookDto {
 
     private Integer quantity;
 
+    private String bookStatus;
+
     private String thumbnailImagePath;
 
     private List<BookImageDto> imagesPath;
@@ -66,6 +68,7 @@ public class BookDto {
                 .details(bookEntity.getDetails())
                 .price(bookEntity.getPrice())
                 .quantity(bookEntity.getQuantity())
+                .bookStatus(String.valueOf(bookEntity.getBookStatus()))
                 .thumbnailImagePath(bookEntity.getThumbnailImagePath())
                 .imagesPath(imagePaths)
                 .userId(bookEntity.getUserEntity().getUserId())

--- a/src/main/java/com/example/bookshop/book/dto/CreateBookDto.java
+++ b/src/main/java/com/example/bookshop/book/dto/CreateBookDto.java
@@ -2,6 +2,7 @@ package com.example.bookshop.book.dto;
 
 import com.example.bookshop.book.entity.BookEntity;
 import com.example.bookshop.book.entity.BookImageEntity;
+import com.example.bookshop.book.type.BookStatus;
 import com.example.bookshop.user.entity.UserEntity;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -62,6 +63,7 @@ public class CreateBookDto {
                     .price(request.getPrice())
                     .quantity(request.getQuantity())
                     .thumbnailImagePath(request.getThumbnailImagePath())
+                    .bookStatus(BookStatus.AVAILABLE)
                     .build();
 
             List<BookImageEntity> imagesPaths = request.getImagesPath().stream()
@@ -93,6 +95,8 @@ public class CreateBookDto {
 
         private Integer quantity;
 
+        private String bookStatus;
+
         private String thumbnailImagePath;
 
         private List<BookImageDto> imagePath;
@@ -115,6 +119,7 @@ public class CreateBookDto {
                     .details(bookDto.getDetails())
                     .price(bookDto.getPrice())
                     .quantity(bookDto.getQuantity())
+                    .bookStatus(bookDto.getBookStatus())
                     .thumbnailImagePath(bookDto.getThumbnailImagePath())
                     .imagePath(bookDto.getImagesPath())
                     .categoryIds(bookDto.getCategoryIds())

--- a/src/main/java/com/example/bookshop/book/dto/UpdateBookDto.java
+++ b/src/main/java/com/example/bookshop/book/dto/UpdateBookDto.java
@@ -1,0 +1,28 @@
+package com.example.bookshop.book.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class UpdateBookDto {
+
+    private Long bookId;
+
+    private String title;
+
+    private String author;
+
+    private String details;
+
+    private String publisher;
+
+    private Integer price;
+
+    private Integer quantity;
+
+    private List<Long> deleteImageIds;
+
+}

--- a/src/main/java/com/example/bookshop/book/entity/BookEntity.java
+++ b/src/main/java/com/example/bookshop/book/entity/BookEntity.java
@@ -1,6 +1,7 @@
 package com.example.bookshop.book.entity;
 
 
+import com.example.bookshop.book.type.BookStatus;
 import com.example.bookshop.category.entity.BookCategory;
 import com.example.bookshop.global.entity.BaseEntity;
 import com.example.bookshop.user.entity.UserEntity;
@@ -44,6 +45,11 @@ public class BookEntity extends BaseEntity {
 
     @OneToMany(mappedBy = "book", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<BookImageEntity> imagesPath;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private BookStatus bookStatus;
+
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")

--- a/src/main/java/com/example/bookshop/book/repository/BookQueryRepository.java
+++ b/src/main/java/com/example/bookshop/book/repository/BookQueryRepository.java
@@ -4,6 +4,7 @@ package com.example.bookshop.book.repository;
 import com.example.bookshop.book.dto.BookDto;
 import com.example.bookshop.book.entity.BookEntity;
 import com.example.bookshop.book.entity.QBookEntity;
+import com.example.bookshop.book.type.BookStatus;
 import com.example.bookshop.category.entity.QBookCategory;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -17,6 +18,8 @@ import org.springframework.util.StringUtils;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
+
+import static com.example.bookshop.book.type.BookStatus.AVAILABLE;
 
 @Repository
 @RequiredArgsConstructor
@@ -69,7 +72,8 @@ public class BookQueryRepository {
                 .from(qBookEntity)
                 .join(qBookEntity.bookCategories, qBookCategory)
                 .fetchJoin()
-                .where(qBookCategory.categoryEntity.categoryId.eq(categoryId))
+                .where(qBookCategory.categoryEntity.categoryId.eq(categoryId)
+                        .and(qBookEntity.bookStatus.eq(AVAILABLE)))
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .orderBy(qBookEntity.createdAt.desc())
@@ -95,12 +99,15 @@ public class BookQueryRepository {
         // 동적 where 조건 구성
         BooleanBuilder builder = new BooleanBuilder();
 
+        builder.and(qBookEntity.bookStatus.eq(AVAILABLE));
 
         if (StringUtils.hasText(keyword)) {
 
             builder.or(qBookEntity.title.containsIgnoreCase(keyword));
             builder.or(qBookEntity.author.containsIgnoreCase(keyword));
             builder.or(qBookEntity.publisher.containsIgnoreCase(keyword));
+
+
 
         }
         return builder;

--- a/src/main/java/com/example/bookshop/book/service/BookService.java
+++ b/src/main/java/com/example/bookshop/book/service/BookService.java
@@ -3,6 +3,8 @@ package com.example.bookshop.book.service;
 
 import com.example.bookshop.book.dto.BookDto;
 import com.example.bookshop.book.dto.CreateBookDto;
+import com.example.bookshop.book.dto.UpdateBookDto;
+import com.example.bookshop.global.dto.CheckDto;
 import com.example.bookshop.global.dto.ResultDto;
 import com.example.bookshop.user.entity.UserEntity;
 import org.springframework.data.domain.Page;
@@ -23,4 +25,10 @@ public interface BookService {
 
 
     ResultDto<Page<BookDto>> searchCategory(Long categoryId, Pageable pageable);
+
+    ResultDto<BookDto> updateBook(UpdateBookDto request, MultipartFile thumbnailImagePath,                  // 새 썸네일 (선택)
+                                  List<MultipartFile> newImagesPaths, Long userId ) throws IOException;
+
+    CheckDto deleteBook(Long bookId, Long userId);
+
 }

--- a/src/main/java/com/example/bookshop/book/type/BookStatus.java
+++ b/src/main/java/com/example/bookshop/book/type/BookStatus.java
@@ -1,0 +1,9 @@
+package com.example.bookshop.book.type;
+
+public enum BookStatus {
+
+    AVAILABLE,   // 정상 (판매 가능)
+    OUT_OF_STOCK, // 품절
+    DELETED // 삭제
+
+}

--- a/src/main/java/com/example/bookshop/category/repository/BookCategoryRepository.java
+++ b/src/main/java/com/example/bookshop/category/repository/BookCategoryRepository.java
@@ -1,0 +1,7 @@
+package com.example.bookshop.category.repository;
+
+import com.example.bookshop.category.entity.BookCategory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BookCategoryRepository extends JpaRepository<BookCategory, Long> {
+}

--- a/src/main/java/com/example/bookshop/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/bookshop/global/exception/ErrorCode.java
@@ -40,8 +40,10 @@ public enum ErrorCode {
     // book
     ALREADY_CREATE_BOOK(HttpStatus.BAD_REQUEST, "이미 등록된 책입니다."),
     NOT_FOUND_BOOK(HttpStatus.BAD_REQUEST, "도서를 찾을 수 없습니다."),
+    NOT_PERMISSION_BOOK(HttpStatus.BAD_REQUEST, "도서에 대한 권한이 없습니다."),
     IMAGE_NOT_FOUND(HttpStatus.BAD_REQUEST, "이미지를 찾을 수 없습니다."),
     IMAGE_UPLOAD_FAIL(HttpStatus.INTERNAL_SERVER_ERROR,"이미지 업로드에 실패했습니다."),
+    IMAGE_DELETE_FAIL(HttpStatus.BAD_REQUEST, "이미지 삭제에 실패하였습니다."),
 
 
     // category


### PR DESCRIPTION
## ✨ 변경 사항

### 📌 AS-IS  
- 도서 수정 기능 미구현  
- 도서 삭제 시 물리 삭제되지 않음 (`DELETE` 기능 미구현)  
- 삭제된 도서가 검색 및 조회 API에서 그대로 노출됨  

---

### 🚀 TO-BE  

#### ✅ 도서 수정 기능 구현
- 사용자가 본인의 도서만 수정 가능하도록 사용자 인증 처리
- 썸네일 이미지 교체 시 기존 썸네일 파일 삭제 후 새로운 이미지 저장
- 상세 이미지 교체 기능:
  - 이미지 ID 리스트 기반으로 기존 이미지 삭제
  - 새로 업로드된 이미지 추가 시 `sortOrder` 기준으로 순차 부여
- 도서의 일반 정보(title, author, price 등) 필드 수정 가능

#### ✅ 도서 삭제 기능 구현 (Soft Delete 방식)
- 실제 DB 삭제 대신 `bookStatus = DELETED` 설정하여 소프트 삭제 처리
- 썸네일 이미지 및 상세 이미지 실제 경로에서 파일 삭제 처리
- 연관 이미지 리스트 초기화 (`imagesPath.clear()`)
- 삭제 요청자가 도서 소유자인지 검증 로직 포함

#### ✅ QueryDSL에서 삭제된 도서 제외 처리
- `BookStatus.DELETED` 상태인 도서를 검색/조회 결과에서 제외


---

## ✅ 체크리스트

- [x] 본인 도서만 수정 및 삭제 가능하도록 검증
- [x] 썸네일 이미지 변경 시 기존 이미지 정상 삭제 확인
- [x] 상세 이미지 일부 삭제 + 일부 추가 시 정상 처리 확인
- [x] 삭제 시 파일 시스템 내 썸네일/상세 이미지 삭제 확인
- [x] 삭제된 도서는 검색/카테고리 결과에서 노출되지 않음



