### PR TITLE
[feat] : 장바구니 상품 등록 및 조회 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,12 +28,37 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
+
+    // jwt
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    testImplementation 'com.h2database:h2'
+
+    // QueryDSL
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
 }
+
+def querydslSrcDir = 'src/main/generated'
+clean {
+    delete file(querydslSrcDir)
+}
+tasks.withType(JavaCompile) {
+    options.generatedSourceOutputDirectory = file(querydslSrcDir)
+}
+
 
 tasks.named('test') {
     useJUnitPlatform()

--- a/src/main/generated/com/example/bookshop/book/entity/QBookEntity.java
+++ b/src/main/generated/com/example/bookshop/book/entity/QBookEntity.java
@@ -72,7 +72,7 @@ public class QBookEntity extends EntityPathBase<BookEntity> {
 
     public QBookEntity(Class<? extends BookEntity> type, PathMetadata metadata, PathInits inits) {
         super(type, metadata, inits);
-        this.userEntity = inits.isInitialized("userEntity") ? new com.example.bookshop.user.entity.QUserEntity(forProperty("userEntity")) : null;
+        this.userEntity = inits.isInitialized("userEntity") ? new com.example.bookshop.user.entity.QUserEntity(forProperty("userEntity"), inits.get("userEntity")) : null;
     }
 
 }

--- a/src/main/generated/com/example/bookshop/user/entity/QUserEntity.java
+++ b/src/main/generated/com/example/bookshop/user/entity/QUserEntity.java
@@ -7,6 +7,7 @@ import com.querydsl.core.types.dsl.*;
 import com.querydsl.core.types.PathMetadata;
 import javax.annotation.processing.Generated;
 import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
 
 
 /**
@@ -17,6 +18,8 @@ public class QUserEntity extends EntityPathBase<UserEntity> {
 
     private static final long serialVersionUID = 728199348L;
 
+    private static final PathInits INITS = PathInits.DIRECT2;
+
     public static final QUserEntity userEntity = new QUserEntity("userEntity");
 
     public final com.example.bookshop.global.entity.QBaseEntity _super = new com.example.bookshop.global.entity.QBaseEntity(this);
@@ -24,6 +27,8 @@ public class QUserEntity extends EntityPathBase<UserEntity> {
     public final StringPath address = createString("address");
 
     public final DatePath<java.time.LocalDate> birth = createDate("birth", java.time.LocalDate.class);
+
+    public final com.example.bookshop.cart.entity.QCartEntity cartEntity;
 
     //inherited
     public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
@@ -52,15 +57,24 @@ public class QUserEntity extends EntityPathBase<UserEntity> {
     public final EnumPath<com.example.bookshop.user.type.UserType> userType = createEnum("userType", com.example.bookshop.user.type.UserType.class);
 
     public QUserEntity(String variable) {
-        super(UserEntity.class, forVariable(variable));
+        this(UserEntity.class, forVariable(variable), INITS);
     }
 
     public QUserEntity(Path<? extends UserEntity> path) {
-        super(path.getType(), path.getMetadata());
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
     }
 
     public QUserEntity(PathMetadata metadata) {
-        super(UserEntity.class, metadata);
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QUserEntity(PathMetadata metadata, PathInits inits) {
+        this(UserEntity.class, metadata, inits);
+    }
+
+    public QUserEntity(Class<? extends UserEntity> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.cartEntity = inits.isInitialized("cartEntity") ? new com.example.bookshop.cart.entity.QCartEntity(forProperty("cartEntity"), inits.get("cartEntity")) : null;
     }
 
 }

--- a/src/main/java/com/example/bookshop/cart/controller/CartController.java
+++ b/src/main/java/com/example/bookshop/cart/controller/CartController.java
@@ -1,0 +1,43 @@
+package com.example.bookshop.cart.controller;
+
+
+import com.example.bookshop.cart.dto.AddCartDto;
+import com.example.bookshop.cart.dto.CartDto;
+import com.example.bookshop.cart.service.CartService;
+import com.example.bookshop.global.dto.ResultDto;
+import com.example.bookshop.user.entity.UserEntity;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/cart")
+public class CartController {
+
+    private final CartService cartService;
+
+
+    @PostMapping()
+    public ResponseEntity<ResultDto<AddCartDto.Response>> addCartItem(
+            @RequestBody AddCartDto.Request request,
+            @AuthenticationPrincipal UserEntity userEntity
+    ) {
+
+        ResultDto<AddCartDto.Response> resultDto = cartService.addCartItem(userEntity.getUserId(), request);
+
+        return ResponseEntity.ok(resultDto);
+    }
+
+
+    @GetMapping()
+    public ResponseEntity<ResultDto<CartDto>> getCartInfo(
+            @AuthenticationPrincipal UserEntity userEntity
+    ) {
+        ResultDto<CartDto> resultDto = cartService.getCartInfo(userEntity.getUserId());
+
+        return ResponseEntity.ok(resultDto);
+    }
+
+}

--- a/src/main/java/com/example/bookshop/cart/dto/CartDto.java
+++ b/src/main/java/com/example/bookshop/cart/dto/CartDto.java
@@ -1,0 +1,33 @@
+package com.example.bookshop.cart.dto;
+
+
+import com.example.bookshop.cart.entity.CartEntity;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.stream.Collectors;
+@AllArgsConstructor
+@Getter
+@Builder
+public class CartDto {
+
+
+    private String username;
+
+    private List<CartItemDto> cartItems;
+
+
+    public static CartDto fromEntity(CartEntity cartEntity) {
+        return CartDto.builder()
+                .username(cartEntity.getUserEntity().getUsername())
+                .cartItems(cartEntity.getCartItems().stream()
+                        .map(CartItemDto::fromEntity)
+                        .collect(Collectors.toList()))
+                .build();
+    }
+
+
+
+}

--- a/src/main/java/com/example/bookshop/cart/dto/CartItemDto.java
+++ b/src/main/java/com/example/bookshop/cart/dto/CartItemDto.java
@@ -1,0 +1,33 @@
+package com.example.bookshop.cart.dto;
+
+
+import com.example.bookshop.cart.entity.CartEntity;
+import com.example.bookshop.cart.entity.CartItem;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class CartItemDto {
+
+    private String title;
+
+    private int quantity;
+
+    private int totalPrice;
+
+    public static CartItemDto fromEntity(CartItem cartItem) {
+
+        return CartItemDto.builder()
+                .title(cartItem.getBookEntity().getTitle())
+                .quantity(cartItem.getQuantity())
+                .totalPrice(cartItem.getTotalPrice())
+                .build();
+
+    }
+
+
+
+}

--- a/src/main/java/com/example/bookshop/cart/entity/CartEntity.java
+++ b/src/main/java/com/example/bookshop/cart/entity/CartEntity.java
@@ -1,0 +1,62 @@
+package com.example.bookshop.cart.entity;
+
+
+import com.example.bookshop.book.entity.BookEntity;
+import com.example.bookshop.user.entity.UserEntity;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@NoArgsConstructor
+@Getter
+public class CartEntity {
+
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long cartId;
+
+    @OneToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private UserEntity userEntity;
+
+    @OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<CartItem> cartItems = new ArrayList<>();
+
+    @Builder
+    public CartEntity(UserEntity userEntity) {
+        this.userEntity = userEntity;
+    }
+
+
+    public void addItemOrUpdate(BookEntity bookEntity, int quantity) {
+
+
+        for (CartItem item : cartItems) {
+
+            if (item.getBookEntity().getBookId().equals(bookEntity.getBookId())) {
+
+                item.setTotalPrice(quantity);
+                return;
+
+            }
+
+        }
+
+        CartItem item = CartItem.builder()
+                .bookEntity(bookEntity)
+                .quantity(quantity)
+                .build();
+
+        item.setCart(this);
+        cartItems.add(item);
+
+
+    }
+
+}

--- a/src/main/java/com/example/bookshop/cart/entity/CartItem.java
+++ b/src/main/java/com/example/bookshop/cart/entity/CartItem.java
@@ -1,0 +1,53 @@
+package com.example.bookshop.cart.entity;
+
+import com.example.bookshop.book.entity.BookEntity;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor
+@Getter
+public class CartItem {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long cartItemId;
+
+    @Column(nullable = false)
+    private int quantity;
+
+    @Column(nullable = false)
+    private int totalPrice;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "book_id")
+    private BookEntity bookEntity;
+
+    @ManyToOne
+    @JoinColumn(name = "cart_id")
+    private CartEntity cartEntity;
+
+
+    @Builder
+    public CartItem(BookEntity bookEntity, int quantity, String title) {
+        this.bookEntity = bookEntity;
+        this.quantity = quantity;
+        this.totalPrice = bookEntity.getPrice() * quantity;
+
+    }
+
+    public void setCart(CartEntity cartEntity) {
+        this.cartEntity = cartEntity;
+    }
+
+
+    public void setTotalPrice(int quantity) {
+
+        this.quantity += quantity;
+
+        this.totalPrice = this.quantity * this.bookEntity.getPrice();
+    }
+
+}

--- a/src/main/java/com/example/bookshop/cart/repository/CartItemRepository.java
+++ b/src/main/java/com/example/bookshop/cart/repository/CartItemRepository.java
@@ -1,0 +1,7 @@
+package com.example.bookshop.cart.repository;
+
+import com.example.bookshop.cart.entity.CartItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CartItemRepository extends JpaRepository<CartItem, Long> {
+}

--- a/src/main/java/com/example/bookshop/cart/repository/CartRepository.java
+++ b/src/main/java/com/example/bookshop/cart/repository/CartRepository.java
@@ -1,0 +1,13 @@
+package com.example.bookshop.cart.repository;
+
+import com.example.bookshop.cart.entity.CartEntity;
+import com.example.bookshop.user.entity.UserEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface CartRepository extends JpaRepository<CartEntity, Long> {
+
+    Optional<CartEntity> findByUserEntity(UserEntity userEntity);
+
+}

--- a/src/main/java/com/example/bookshop/cart/service/CartService.java
+++ b/src/main/java/com/example/bookshop/cart/service/CartService.java
@@ -1,0 +1,15 @@
+package com.example.bookshop.cart.service;
+
+import com.example.bookshop.cart.dto.AddCartDto;
+import com.example.bookshop.cart.dto.CartDto;
+import com.example.bookshop.global.dto.ResultDto;
+
+public interface CartService {
+
+
+    ResultDto<AddCartDto.Response> addCartItem(Long userId, AddCartDto.Request request);
+
+
+    ResultDto<CartDto> getCartInfo(Long userId);
+
+}

--- a/src/main/java/com/example/bookshop/cart/service/impl/CartServiceImpl.java
+++ b/src/main/java/com/example/bookshop/cart/service/impl/CartServiceImpl.java
@@ -1,0 +1,88 @@
+package com.example.bookshop.cart.service.impl;
+
+import com.example.bookshop.book.entity.BookEntity;
+import com.example.bookshop.book.repository.BookRepository;
+import com.example.bookshop.book.type.BookStatus;
+import com.example.bookshop.cart.dto.AddCartDto;
+import com.example.bookshop.cart.dto.CartDto;
+import com.example.bookshop.cart.entity.CartEntity;
+import com.example.bookshop.cart.repository.CartItemRepository;
+import com.example.bookshop.cart.repository.CartRepository;
+import com.example.bookshop.cart.service.CartService;
+import com.example.bookshop.global.dto.ResultDto;
+import com.example.bookshop.global.exception.CustomException;
+import com.example.bookshop.global.exception.ErrorCode;
+import com.example.bookshop.user.entity.UserEntity;
+import com.example.bookshop.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.example.bookshop.global.exception.ErrorCode.*;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CartServiceImpl implements CartService {
+
+
+    private final CartRepository cartRepository;
+
+
+    private final UserRepository userRepository;
+
+    private final BookRepository bookRepository;
+
+    @Override
+    @Transactional
+    public ResultDto<AddCartDto.Response> addCartItem(Long userId, AddCartDto.Request request) {
+
+        log.info("[장바구니 상품 등록 시작] userId={}, bookId={}", userId, request.getBookId());
+
+        UserEntity userEntity = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+        BookEntity bookEntity = bookRepository.findById(request.getBookId())
+                .orElseThrow(() -> new CustomException(NOT_FOUND_BOOK));
+
+
+        if (bookEntity.getBookStatus().equals(BookStatus.DELETED) || bookEntity.getQuantity() < request.getQuantity()) {
+            throw new CustomException(CANNOT_ADD_TO_CART);
+        }
+
+        CartEntity newCart = cartRepository.findByUserEntity(userEntity)
+                .orElseGet(
+                        () -> {
+                            CartEntity cartEntity = CartEntity.builder()
+                                    .userEntity(userEntity)
+                                    .build();
+                            return cartRepository.save(cartEntity);
+                        }
+                );
+
+        newCart.addItemOrUpdate(bookEntity, request.getQuantity());
+        cartRepository.save(newCart);
+
+        CartDto cartDto = CartDto.fromEntity(newCart);
+
+        log.info("[장바구니 상품 담기 완료] userId={}, bookId={}", userId, request.getBookId());
+
+        return ResultDto.of("장바구니 담기에 성공하였습니다.", AddCartDto.Response.fromDto(cartDto));
+    }
+
+    @Override
+    public ResultDto<CartDto> getCartInfo(Long userId) {
+
+        UserEntity userEntity = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+        CartEntity cartEntity = cartRepository.findByUserEntity(userEntity)
+                .orElseThrow(() -> new CustomException(CART_NOT_FOUND));
+
+        CartDto cartDto = CartDto.fromEntity(cartEntity);
+
+
+        return ResultDto.of("장바구니 조회 완료.", cartDto);
+    }
+}

--- a/src/main/java/com/example/bookshop/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/bookshop/global/exception/ErrorCode.java
@@ -48,7 +48,11 @@ public enum ErrorCode {
 
     // category
     NOT_FOUND_CATEGORY(HttpStatus.BAD_REQUEST, "카테고리를 찾을 수 없습니다."),
-    ALREADY_EXIST_CATEGORY(HttpStatus.BAD_REQUEST, "이미 존재하는 카테고리입니다.");
+    ALREADY_EXIST_CATEGORY(HttpStatus.BAD_REQUEST, "이미 존재하는 카테고리입니다."),
+
+    // cart
+    CANNOT_ADD_TO_CART(HttpStatus.BAD_REQUEST, "장바구니에 담을 수 없는 상품입니다."),
+    CART_NOT_FOUND(HttpStatus.BAD_REQUEST, "장바구니를 찾을 수 없습니다.");
 
 
     private final HttpStatus status;

--- a/src/main/java/com/example/bookshop/user/entity/UserEntity.java
+++ b/src/main/java/com/example/bookshop/user/entity/UserEntity.java
@@ -1,6 +1,7 @@
 package com.example.bookshop.user.entity;
 
 
+import com.example.bookshop.cart.entity.CartEntity;
 import com.example.bookshop.global.entity.BaseEntity;
 import com.example.bookshop.user.dto.EditUserInfo;
 import com.example.bookshop.user.type.UserState;
@@ -62,6 +63,9 @@ public class UserEntity extends BaseEntity implements UserDetails {
 
 
     private boolean emailAuth = false;
+
+    @OneToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private CartEntity cartEntity;
 
 
     public void setEmailAuth() {

--- a/src/test/java/com/example/bookshop/cart/service/impl/CartServiceImplTest.java
+++ b/src/test/java/com/example/bookshop/cart/service/impl/CartServiceImplTest.java
@@ -1,0 +1,196 @@
+package com.example.bookshop.cart.service.impl;
+
+import com.example.bookshop.book.dto.CreateBookDto;
+import com.example.bookshop.book.entity.BookEntity;
+import com.example.bookshop.book.repository.BookQueryRepository;
+import com.example.bookshop.book.repository.BookRepository;
+import com.example.bookshop.book.service.BookService;
+import com.example.bookshop.cart.dto.AddCartDto;
+import com.example.bookshop.cart.entity.CartEntity;
+import com.example.bookshop.cart.repository.CartRepository;
+import com.example.bookshop.cart.service.CartService;
+import com.example.bookshop.category.entity.CategoryEntity;
+import com.example.bookshop.category.repository.CategoryRepository;
+import com.example.bookshop.global.dto.ResultDto;
+import com.example.bookshop.global.exception.CustomException;
+import com.example.bookshop.global.exception.ErrorCode;
+import com.example.bookshop.user.dto.SignUpUserDto;
+import com.example.bookshop.user.entity.UserEntity;
+import com.example.bookshop.user.repository.UserRepository;
+import com.example.bookshop.user.service.UserService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+@SpringBootTest
+@Transactional
+@ActiveProfiles("test")
+class CartServiceImplTest {
+    @Autowired
+    private UserService userService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private BookService bookService;
+
+    @Autowired
+    private BookRepository bookRepository;
+
+    @Autowired
+    private CartService cartService;
+
+    @Autowired
+    private CategoryRepository categoryRepository;
+
+    @Autowired
+    private CartRepository cartRepository;
+
+    @TempDir
+    Path tempDir;
+
+    @BeforeEach
+    void setUp() throws IOException {
+
+        UserEntity userEntity = new UserEntity();
+
+        if (!userRepository.existsByEmail("test@example.com")) {
+
+
+            SignUpUserDto.Request build = SignUpUserDto.Request.builder()
+                    .loginId("testuser")
+                    .password("1111@11")
+                    .checkPassword("1111@11")
+                    .email("test@example.com")
+                    .nickname("testuser")
+                    .birth(LocalDate.parse("2000-01-01"))
+                    .phone("010-1111-1111")
+                    .address("테스트 주소")
+                    .build();
+
+
+            userService.signUpUser(build);
+
+            userEntity = userRepository.findByLoginId("testuser").orElseThrow();
+            userEntity.setEmailAuth();
+            userRepository.save(userEntity);
+
+        }
+
+        if (!bookRepository.existsByTitle("테스트 도서 제목")) {
+            CategoryEntity category = categoryRepository.save(new CategoryEntity("프로그래밍", null));
+
+
+            List<Long> categoryId = List.of(category.getCategoryId());
+
+            CreateBookDto.Request request = CreateBookDto.Request.builder()
+                    .title("테스트 도서 제목")
+                    .author("테스트 도서 저자")
+                    .publisher("테스트 도서 출판사")
+                    .price(10000)
+                    .quantity(50)
+                    .details("테스트 상세 설명")
+                    .categoryIds(categoryId)
+                    .build();
+
+            MultipartFile mockImage = createMockImage("thumbnail.jpg");
+
+            List<MultipartFile> details = List.of(
+                    createMockImage("detail1.jpg"),
+                    createMockImage("detail2.jpg")
+            );
+
+            bookService.createBook(request, mockImage, details, userEntity.getUserId());
+        }
+
+    }
+
+
+    @Test
+    @DisplayName("장바구니 상품 추가 테스트")
+    void addCartItem() {
+        // given
+        UserEntity userEntity = userRepository.findById(1L)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        BookEntity bookEntity = bookRepository.findById(1L)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_BOOK));
+
+
+        AddCartDto.Request request = new AddCartDto.Request(bookEntity.getBookId(), 3);
+
+        // when
+
+        cartService.addCartItem(userEntity.getUserId(), request);
+
+        CartEntity cartEntity = cartRepository.findByUserEntity(userEntity)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        // then
+
+        assertEquals(cartEntity.getUserEntity().getUsername(), userEntity.getUsername());
+        assertEquals(3, cartEntity.getCartItems().get(0).getQuantity());
+
+
+
+    }
+
+    @Test
+    @DisplayName("장바구니에 동일한 도서를 두 번 추가하면 수량이 누적된다")
+    void addSameBookTwice_quantityIncreases() {
+        // given
+        UserEntity user = userRepository.findByLoginId("testuser")
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        BookEntity book = bookRepository.findByTitle("테스트 도서 제목")
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_BOOK));
+
+        AddCartDto.Request firstRequest = new AddCartDto.Request(book.getBookId(), 2);
+        AddCartDto.Request secondRequest = new AddCartDto.Request(book.getBookId(), 5);
+
+        // when
+        cartService.addCartItem(user.getUserId(), firstRequest); // 2개 추가
+        cartService.addCartItem(user.getUserId(), secondRequest); // 5개 추가
+
+        CartEntity cart = cartRepository.findByUserEntity(user)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        // then
+        assertEquals(1, cart.getCartItems().size());
+        assertEquals(7, cart.getCartItems().get(0).getQuantity());
+        assertEquals(book.getTitle(), cart.getCartItems().get(0).getBookEntity().getTitle());
+    }
+
+
+
+
+
+
+    private MultipartFile createMockImage(String fileName) throws IOException {
+
+        Path path = tempDir.resolve(fileName);
+
+        Files.write(path, "fake-image-content".getBytes());
+
+        return new MockMultipartFile(
+                "file", fileName, "image/jpeg", Files.readAllBytes(path)
+        );
+
+    }
+
+}


### PR DESCRIPTION
## ✨ 변경 사항

### 📌 AS-IS  
- 장바구니 도서 등록 및 조회 기능 미구현

---

### 🚀 TO-BE  

#### ✅ 장바구니 도서 등록 구현
- UserEntity <-> CartEntity <-> CartItem <-> BookEntity 연관 관계 설정
  - CartItem 중간 테이블 도입 (BookEntity 직접 연관 회피)
- 장바구니 등록 시 예외 처리
  - 도서가 삭제 상태인 경우
  - 재고 수량이 부족한 경우
- 중복 도서 등록 시 기존 CartItem에 수량 누적 및 totalPrice 재계산

#### ✅ 장바구니 조회 API 구현
- 로그인한 사용자(UserId 기반)의 장바구니 정보 조회 기능 구현

---

## ✅ 체크리스트

- [x] 본인 장바구니만 조회 가능
- [x] 장바구니 등록 및 중복 도서 수량 증가 처리
- [x] 장바구니 등록 예외 처리 (삭제 상태, 재고 부족)
- [x] 테스트 코드 작성
