### PR TITLE
[feat] : 장바구니 수량 수정 및 삭제 기능 구현

### DIFF
--- a/src/main/generated/com/example/bookshop/cart/entity/QCartEntity.java
+++ b/src/main/generated/com/example/bookshop/cart/entity/QCartEntity.java
@@ -1,0 +1,53 @@
+package com.example.bookshop.cart.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QCartEntity is a Querydsl query type for CartEntity
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QCartEntity extends EntityPathBase<CartEntity> {
+
+    private static final long serialVersionUID = 1208856670L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QCartEntity cartEntity = new QCartEntity("cartEntity");
+
+    public final NumberPath<Long> cartId = createNumber("cartId", Long.class);
+
+    public final ListPath<CartItem, QCartItem> cartItems = this.<CartItem, QCartItem>createList("cartItems", CartItem.class, QCartItem.class, PathInits.DIRECT2);
+
+    public final com.example.bookshop.user.entity.QUserEntity userEntity;
+
+    public QCartEntity(String variable) {
+        this(CartEntity.class, forVariable(variable), INITS);
+    }
+
+    public QCartEntity(Path<? extends CartEntity> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QCartEntity(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QCartEntity(PathMetadata metadata, PathInits inits) {
+        this(CartEntity.class, metadata, inits);
+    }
+
+    public QCartEntity(Class<? extends CartEntity> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.userEntity = inits.isInitialized("userEntity") ? new com.example.bookshop.user.entity.QUserEntity(forProperty("userEntity"), inits.get("userEntity")) : null;
+    }
+
+}
+

--- a/src/main/generated/com/example/bookshop/cart/entity/QCartItem.java
+++ b/src/main/generated/com/example/bookshop/cart/entity/QCartItem.java
@@ -1,0 +1,56 @@
+package com.example.bookshop.cart.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QCartItem is a Querydsl query type for CartItem
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QCartItem extends EntityPathBase<CartItem> {
+
+    private static final long serialVersionUID = -1299174834L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QCartItem cartItem = new QCartItem("cartItem");
+
+    public final com.example.bookshop.book.entity.QBookEntity bookEntity;
+
+    public final QCartEntity cartEntity;
+
+    public final NumberPath<Long> cartItemId = createNumber("cartItemId", Long.class);
+
+    public final NumberPath<Integer> quantity = createNumber("quantity", Integer.class);
+
+    public QCartItem(String variable) {
+        this(CartItem.class, forVariable(variable), INITS);
+    }
+
+    public QCartItem(Path<? extends CartItem> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QCartItem(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QCartItem(PathMetadata metadata, PathInits inits) {
+        this(CartItem.class, metadata, inits);
+    }
+
+    public QCartItem(Class<? extends CartItem> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.bookEntity = inits.isInitialized("bookEntity") ? new com.example.bookshop.book.entity.QBookEntity(forProperty("bookEntity"), inits.get("bookEntity")) : null;
+        this.cartEntity = inits.isInitialized("cartEntity") ? new QCartEntity(forProperty("cartEntity"), inits.get("cartEntity")) : null;
+    }
+
+}
+

--- a/src/main/java/com/example/bookshop/cart/controller/CartController.java
+++ b/src/main/java/com/example/bookshop/cart/controller/CartController.java
@@ -3,11 +3,14 @@ package com.example.bookshop.cart.controller;
 
 import com.example.bookshop.cart.dto.AddCartDto;
 import com.example.bookshop.cart.dto.CartDto;
+import com.example.bookshop.cart.dto.UpdateCartDto;
 import com.example.bookshop.cart.service.CartService;
+import com.example.bookshop.global.dto.CheckDto;
 import com.example.bookshop.global.dto.ResultDto;
 import com.example.bookshop.user.entity.UserEntity;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -19,7 +22,8 @@ public class CartController {
     private final CartService cartService;
 
 
-    @PostMapping()
+    @PostMapping
+    @PreAuthorize("hasAnyRole('USER')")
     public ResponseEntity<ResultDto<AddCartDto.Response>> addCartItem(
             @RequestBody AddCartDto.Request request,
             @AuthenticationPrincipal UserEntity userEntity
@@ -31,13 +35,51 @@ public class CartController {
     }
 
 
-    @GetMapping()
+    @GetMapping
+    @PreAuthorize("hasAnyRole('USER')")
     public ResponseEntity<ResultDto<CartDto>> getCartInfo(
             @AuthenticationPrincipal UserEntity userEntity
     ) {
         ResultDto<CartDto> resultDto = cartService.getCartInfo(userEntity.getUserId());
 
         return ResponseEntity.ok(resultDto);
+    }
+
+    @PatchMapping("/update")
+    @PreAuthorize("hasAnyRole('USER')")
+    public ResponseEntity<ResultDto<CartDto>> updateCartItem(
+            @RequestBody UpdateCartDto request,
+            @AuthenticationPrincipal UserEntity userEntity
+    ) {
+
+        ResultDto<CartDto> cartDtoResultDto = cartService.updateCartItem(userEntity.getUserId(), request);
+
+        return ResponseEntity.ok(cartDtoResultDto);
+    }
+
+
+    @PatchMapping
+    @PreAuthorize("hasAnyRole('USER')")
+    public ResponseEntity<CheckDto> deleteCartItem(
+            @RequestParam Long cartItemId,
+            @AuthenticationPrincipal UserEntity userEntity
+    ) {
+
+        CheckDto checkDto = cartService.deleteCartItem(userEntity.getUserId(), cartItemId);
+
+        return ResponseEntity.ok(checkDto);
+    }
+
+    @PatchMapping("/delete-all")
+    @PreAuthorize("hasAnyRole('USER')")
+    public ResponseEntity<CheckDto> deleteAllCartItems(
+            @RequestParam Long cartId,
+            @AuthenticationPrincipal UserEntity userEntity
+    ) {
+
+        CheckDto checkDto = cartService.deleteAllCartItems(userEntity.getUserId(), cartId);
+
+        return ResponseEntity.ok(checkDto);
     }
 
 }

--- a/src/main/java/com/example/bookshop/cart/dto/CartDto.java
+++ b/src/main/java/com/example/bookshop/cart/dto/CartDto.java
@@ -18,13 +18,23 @@ public class CartDto {
 
     private List<CartItemDto> cartItems;
 
+    int totalPrice;
+
 
     public static CartDto fromEntity(CartEntity cartEntity) {
+
+        List<CartItemDto> itemDtos = cartEntity.getCartItems().stream()
+                .map(CartItemDto::fromEntity)
+                .toList();
+
+        int total = itemDtos.stream()
+                .mapToInt(CartItemDto::getTotalPrice)
+                .sum();
+
         return CartDto.builder()
                 .username(cartEntity.getUserEntity().getUsername())
-                .cartItems(cartEntity.getCartItems().stream()
-                        .map(CartItemDto::fromEntity)
-                        .collect(Collectors.toList()))
+                .cartItems(itemDtos)
+                .totalPrice(total)
                 .build();
     }
 

--- a/src/main/java/com/example/bookshop/cart/dto/CartItemDto.java
+++ b/src/main/java/com/example/bookshop/cart/dto/CartItemDto.java
@@ -16,14 +16,22 @@ public class CartItemDto {
 
     private int quantity;
 
+    private int unitPrice;
+
     private int totalPrice;
 
     public static CartItemDto fromEntity(CartItem cartItem) {
 
+        int unitPrice = cartItem.getBookEntity().getPrice();
+
+        int totalPrice = cartItem.getQuantity() * unitPrice;
+
+
         return CartItemDto.builder()
                 .title(cartItem.getBookEntity().getTitle())
                 .quantity(cartItem.getQuantity())
-                .totalPrice(cartItem.getTotalPrice())
+                .unitPrice(unitPrice)
+                .totalPrice(totalPrice)
                 .build();
 
     }

--- a/src/main/java/com/example/bookshop/cart/dto/UpdateCartDto.java
+++ b/src/main/java/com/example/bookshop/cart/dto/UpdateCartDto.java
@@ -1,0 +1,13 @@
+package com.example.bookshop.cart.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class UpdateCartDto {
+
+    private Long bookId;
+
+    private int quantity;
+}

--- a/src/main/java/com/example/bookshop/cart/entity/CartEntity.java
+++ b/src/main/java/com/example/bookshop/cart/entity/CartEntity.java
@@ -2,6 +2,8 @@ package com.example.bookshop.cart.entity;
 
 
 import com.example.bookshop.book.entity.BookEntity;
+import com.example.bookshop.global.exception.CustomException;
+import com.example.bookshop.global.exception.ErrorCode;
 import com.example.bookshop.user.entity.UserEntity;
 import jakarta.persistence.*;
 import lombok.Builder;
@@ -41,7 +43,7 @@ public class CartEntity {
 
             if (item.getBookEntity().getBookId().equals(bookEntity.getBookId())) {
 
-                item.setTotalPrice(quantity);
+                item.addQuantity(quantity);
                 return;
 
             }
@@ -56,6 +58,16 @@ public class CartEntity {
         item.setCart(this);
         cartItems.add(item);
 
+
+    }
+
+    public void removeCartItem(Long cartItemId) {
+
+        boolean removed = cartItems.removeIf(item -> item.getCartItemId().equals(cartItemId));
+
+        if (!removed) {
+            throw new CustomException(ErrorCode.NOT_FOUND_CART_ITEM);
+        }
 
     }
 

--- a/src/main/java/com/example/bookshop/cart/entity/CartItem.java
+++ b/src/main/java/com/example/bookshop/cart/entity/CartItem.java
@@ -18,8 +18,6 @@ public class CartItem {
     @Column(nullable = false)
     private int quantity;
 
-    @Column(nullable = false)
-    private int totalPrice;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "book_id")
@@ -34,7 +32,7 @@ public class CartItem {
     public CartItem(BookEntity bookEntity, int quantity, String title) {
         this.bookEntity = bookEntity;
         this.quantity = quantity;
-        this.totalPrice = bookEntity.getPrice() * quantity;
+
 
     }
 
@@ -43,11 +41,16 @@ public class CartItem {
     }
 
 
-    public void setTotalPrice(int quantity) {
+    public void addQuantity(int quantity) {
 
         this.quantity += quantity;
 
-        this.totalPrice = this.quantity * this.bookEntity.getPrice();
+
+    }
+
+    public void updateQuantity(int newQuantity) {
+
+        this.quantity = newQuantity;
     }
 
 }

--- a/src/main/java/com/example/bookshop/cart/repository/CartItemRepository.java
+++ b/src/main/java/com/example/bookshop/cart/repository/CartItemRepository.java
@@ -1,7 +1,13 @@
 package com.example.bookshop.cart.repository;
 
+import com.example.bookshop.book.entity.BookEntity;
+import com.example.bookshop.cart.entity.CartEntity;
 import com.example.bookshop.cart.entity.CartItem;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface CartItemRepository extends JpaRepository<CartItem, Long> {
+
+    Optional<CartItem> findByCartEntityAndBookEntity(CartEntity cartEntity, BookEntity bookEntity);
 }

--- a/src/main/java/com/example/bookshop/cart/repository/CartRepository.java
+++ b/src/main/java/com/example/bookshop/cart/repository/CartRepository.java
@@ -10,4 +10,8 @@ public interface CartRepository extends JpaRepository<CartEntity, Long> {
 
     Optional<CartEntity> findByUserEntity(UserEntity userEntity);
 
+
+
+
+
 }

--- a/src/main/java/com/example/bookshop/cart/service/CartService.java
+++ b/src/main/java/com/example/bookshop/cart/service/CartService.java
@@ -2,6 +2,8 @@ package com.example.bookshop.cart.service;
 
 import com.example.bookshop.cart.dto.AddCartDto;
 import com.example.bookshop.cart.dto.CartDto;
+import com.example.bookshop.cart.dto.UpdateCartDto;
+import com.example.bookshop.global.dto.CheckDto;
 import com.example.bookshop.global.dto.ResultDto;
 
 public interface CartService {
@@ -12,4 +14,10 @@ public interface CartService {
 
     ResultDto<CartDto> getCartInfo(Long userId);
 
+
+    ResultDto<CartDto> updateCartItem(Long userId, UpdateCartDto request);
+
+    CheckDto deleteCartItem(Long userId, Long cartItemId);
+
+    CheckDto deleteAllCartItems(Long userId, Long cartId);
 }

--- a/src/main/java/com/example/bookshop/category/service/impl/CategoryServiceImpl.java
+++ b/src/main/java/com/example/bookshop/category/service/impl/CategoryServiceImpl.java
@@ -48,7 +48,7 @@ public class CategoryServiceImpl implements CategoryService {
             throw new CustomException(ErrorCode.ALREADY_EXIST_CATEGORY);
         }
 
-        /**
+        /*
          * 자식 카테고리 생성 부모 객체와 연결
          */
         CategoryEntity categoryEntity = new CategoryEntity(request.getCategoryName(), parent);
@@ -64,7 +64,7 @@ public class CategoryServiceImpl implements CategoryService {
     @Override
     public ResultDto<List<CategoryDto>> getCategoryTree() {
 
-        /**
+        /*
          * 부모객체가 없는 최상위 부모를 탐색 후 자식 객체와 함께 리스트로 반환
          */
         List<CategoryDto> categoryLists = categoryRepository.findByParentIsNull().stream()

--- a/src/main/java/com/example/bookshop/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/bookshop/global/exception/ErrorCode.java
@@ -52,7 +52,9 @@ public enum ErrorCode {
 
     // cart
     CANNOT_ADD_TO_CART(HttpStatus.BAD_REQUEST, "장바구니에 담을 수 없는 상품입니다."),
-    CART_NOT_FOUND(HttpStatus.BAD_REQUEST, "장바구니를 찾을 수 없습니다.");
+    CART_NOT_FOUND(HttpStatus.BAD_REQUEST, "장바구니를 찾을 수 없습니다."),
+    INVALID_QUANTITY(HttpStatus.BAD_REQUEST, "수량을 잘못 입력하였습니다."),
+    NOT_FOUND_CART_ITEM(HttpStatus.BAD_REQUEST, "장바구니 상품을 찾을 수 없습니다.");
 
 
     private final HttpStatus status;


### PR DESCRIPTION
## ✨ 변경 사항

### 📌 AS-IS
- 장바구니 도서 수정 및 삭제 기능 미구현

---

### 🚀 TO-BE

#### ✅ 장바구니 도서 수량 수정 기능 구현
- 장바구니 안의 도서의 수량 수정 기능 구현
- 존재하지 않는 사용자/장바구니/도서/CartItem 예외 처리
- 수정 시 CartItem의 수량 및 총 금액(totalPrice) 동시 업데이트

#### ✅ 장바구니 도서 삭제 기능 구현
- 장바구니 내 개별 도서(CartItem) 삭제 기능 구현
- 본인 장바구니의 아이템만 삭제 가능하도록 검증
- CartItem 삭제 시 장바구니의 전체 금액도 동기화

### ✅ 체크리스트
- [x] 본인 장바구니 아이템만 삭제/수정 가능
- [x] 수량 수정 API 예외 처리
  - [x] 0 이하 입력
  - [x] 미존재 도서/장바구니/CartItem
- [x] 삭제 시 연관된 CartItem만 제거 (도서/유저는 영향 없음)
- [x] 장바구니 전체 금액 자동 반영
