### PR TITLE
[refactor] : 장바구니 조회 시 레디스 캐시 적용

### DIFF
--- a/src/main/java/com/example/bookshop/cart/repository/CartRepository.java
+++ b/src/main/java/com/example/bookshop/cart/repository/CartRepository.java
@@ -12,6 +12,8 @@ import java.util.Optional;
 public interface CartRepository extends JpaRepository<CartEntity, Long> {
 
 
+    Optional<CartEntity> findByUserEntity(UserEntity userEntity);
+
     @Query("""
         select c
         from CartEntity c
@@ -20,6 +22,7 @@ public interface CartRepository extends JpaRepository<CartEntity, Long> {
         where c.userEntity = :user
 """)
     Optional<CartEntity> findByUserWithItemsAndBooks(@Param("user") UserEntity userEntity);
+
 
 
 

--- a/src/main/java/com/example/bookshop/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/bookshop/global/exception/ErrorCode.java
@@ -11,6 +11,8 @@ public enum ErrorCode {
 
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "내부 서버 오류입니다."),
 
+    // json
+
 
     // JWT
     NOT_FOUND_TOKEN(HttpStatus.UNAUTHORIZED, "토큰이 존재하지 않습니다."),
@@ -54,7 +56,15 @@ public enum ErrorCode {
     CANNOT_ADD_TO_CART(HttpStatus.BAD_REQUEST, "장바구니에 담을 수 없는 상품입니다."),
     CART_NOT_FOUND(HttpStatus.BAD_REQUEST, "장바구니를 찾을 수 없습니다."),
     INVALID_QUANTITY(HttpStatus.BAD_REQUEST, "수량을 잘못 입력하였습니다."),
-    NOT_FOUND_CART_ITEM(HttpStatus.BAD_REQUEST, "장바구니 상품을 찾을 수 없습니다.");
+    NOT_FOUND_CART_ITEM(HttpStatus.BAD_REQUEST, "장바구니 상품을 찾을 수 없습니다."),
+
+
+    // order
+    OUT_OF_STOCK(HttpStatus.BAD_REQUEST, "재고가 부족합니다.")
+
+
+
+    ;
 
 
     private final HttpStatus status;


### PR DESCRIPTION
## ✨ 변경 사항

### 📌 AS-IS  
- 장바구니 조회 시 사용자 요청량이 많아지면 응답 지연 발생

---

### 🚀 TO-BE  

#### ✅ Redis 캐시 기반 장바구니 조회 리팩토링  
1. **Redis Key**: `cart:{userId}` 
2. Redis에 키 값 저장 후 장바구니 조회 시 응답 DTO 반환 -> 응답 시간 단축 확인
4. **캐시 무효화**:  
   - 장바구니 변경, 삭제 시 레디스 키 존재 시 삭제함으로써 캐시 무효화

---

### ✅ 체크리스트
- [x]  Redis 조회/저장 로직 구현
- [x] 응답 시간 단축 확인  
- [x] 장바구니 변경 및 삭제 API 호출 시 캐시 삭제  
